### PR TITLE
chore: ✨Make jest + enzyme work

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,7 +1,11 @@
 {
   "parser": "@typescript-eslint/parser",
-  "extends": ["airbnb-typescript", "plugin:@typescript-eslint/recommended", "prettier", "prettier/react", "prettier/@typescript-eslint"],
-  "plugins": ["@typescript-eslint"],
+  "env": {
+    "jest": true,
+    "node": true
+  },
+  "extends": ["airbnb-typescript", "plugin:@typescript-eslint/recommended", "plugin:react/recommended", "prettier", "prettier/react", "prettier/@typescript-eslint"],
+  "plugins": ["@typescript-eslint", "react"],
   "parserOptions": {
     "project": "./tsconfig.json",
     "ecmaFeatures": {
@@ -9,6 +13,8 @@
     }
   },
   "rules": {
-    "react/prefer-stateless-function": 0
+    "react/prefer-stateless-function": 0,
+    "react/button-has-type": 0,
+    "import/no-extraneous-dependencies": 0
   }
 }

--- a/babel.config.js
+++ b/babel.config.js
@@ -2,7 +2,7 @@ const basic = {
   "presets": [
     ["@babel/preset-env", {
       "debug": true,
-      "modules": "cjs"
+      "modules": false
     }],
     ["@babel/preset-react"],
     ["@babel/preset-typescript"]

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,8 +1,8 @@
-{
+const basic = {
   "presets": [
     ["@babel/preset-env", {
       "debug": true,
-      "modules": false
+      "modules": "cjs"
     }],
     ["@babel/preset-react"],
     ["@babel/preset-typescript"]
@@ -12,4 +12,11 @@
     ["@babel/plugin-proposal-object-rest-spread"],
     ["@babel/plugin-proposal-class-properties"]
   ]
+}
+
+module.exports = function babel(api) {
+  if(api.env('test')) {
+    basic.presets[0][1].modules = 'cjs'
+  }
+  return basic;
 }

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,18 @@
+
+module.exports = {
+  setupFiles: ["<rootDir>/scripts/jest/setupTests.js"],
+  "verbose": true,
+  snapshotSerializers: ["enzyme-to-json/serializer"],
+  moduleNameMapper: {
+    "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "<rootDir>/scripts/jest/__mocks__/fileMock.js",
+    "\\.(css|styl)$": "<rootDir>/scripts/jest/__mocks__/styleMock.js"
+  },
+  moduleFileExtensions: [
+    'ts',
+    'tsx',
+    'js',
+    'jsx',
+    'json',
+    'node',
+  ],
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1134,6 +1134,16 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "@cnakazawa/watch": {
+      "version": "1.0.3",
+      "resolved": "http://registry.npm.taobao.org/@cnakazawa/watch/download/@cnakazawa/watch-1.0.3.tgz",
+      "integrity": "sha1-CZE56ux+vweifBeGo/9k85Rk0u8=",
+      "dev": true,
+      "requires": {
+        "exec-sh": "^0.3.2",
+        "minimist": "^1.2.0"
+      }
+    },
     "@commitlint/cli": {
       "version": "7.2.1",
       "resolved": "http://registry.npm.taobao.org/@commitlint/cli/download/@commitlint/cli-7.2.1.tgz",
@@ -1300,6 +1310,208 @@
         "find-up": "^2.1.0"
       }
     },
+    "@jest/console": {
+      "version": "24.3.0",
+      "resolved": "http://registry.npm.taobao.org/@jest/console/download/@jest/console-24.3.0.tgz",
+      "integrity": "sha1-e9kg0lCYi6C/E1LESTpI4cuXZx4=",
+      "dev": true,
+      "requires": {
+        "@jest/source-map": "^24.3.0",
+        "@types/node": "*",
+        "chalk": "^2.0.1",
+        "slash": "^2.0.0"
+      }
+    },
+    "@jest/core": {
+      "version": "24.5.0",
+      "resolved": "http://registry.npm.taobao.org/@jest/core/download/@jest/core-24.5.0.tgz",
+      "integrity": "sha1-LO/Gpp6evK4dqPfHX4olcVK6HsA=",
+      "dev": true,
+      "requires": {
+        "@jest/console": "^24.3.0",
+        "@jest/reporters": "^24.5.0",
+        "@jest/test-result": "^24.5.0",
+        "@jest/transform": "^24.5.0",
+        "@jest/types": "^24.5.0",
+        "ansi-escapes": "^3.0.0",
+        "chalk": "^2.0.1",
+        "exit": "^0.1.2",
+        "graceful-fs": "^4.1.15",
+        "jest-changed-files": "^24.5.0",
+        "jest-config": "^24.5.0",
+        "jest-haste-map": "^24.5.0",
+        "jest-message-util": "^24.5.0",
+        "jest-regex-util": "^24.3.0",
+        "jest-resolve-dependencies": "^24.5.0",
+        "jest-runner": "^24.5.0",
+        "jest-runtime": "^24.5.0",
+        "jest-snapshot": "^24.5.0",
+        "jest-util": "^24.5.0",
+        "jest-validate": "^24.5.0",
+        "jest-watcher": "^24.5.0",
+        "micromatch": "^3.1.10",
+        "p-each-series": "^1.0.0",
+        "pirates": "^4.0.1",
+        "realpath-native": "^1.1.0",
+        "rimraf": "^2.5.4",
+        "strip-ansi": "^5.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "http://registry.npm.taobao.org/ansi-regex/download/ansi-regex-4.1.0.tgz",
+          "integrity": "sha1-i5+PCM8ay4Q3Vqg5yox+MWjFGZc=",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "5.1.0",
+          "resolved": "http://registry.npm.taobao.org/strip-ansi/download/strip-ansi-5.1.0.tgz",
+          "integrity": "sha1-VaqlTjO0wGSaczikNDexiH0VPsQ=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        }
+      }
+    },
+    "@jest/environment": {
+      "version": "24.5.0",
+      "resolved": "http://registry.npm.taobao.org/@jest/environment/download/@jest/environment-24.5.0.tgz",
+      "integrity": "sha1-olV/eAh2er6j+eTMQ6FyEipjrKg=",
+      "dev": true,
+      "requires": {
+        "@jest/fake-timers": "^24.5.0",
+        "@jest/transform": "^24.5.0",
+        "@jest/types": "^24.5.0",
+        "@types/node": "*",
+        "jest-mock": "^24.5.0"
+      }
+    },
+    "@jest/fake-timers": {
+      "version": "24.5.0",
+      "resolved": "http://registry.npm.taobao.org/@jest/fake-timers/download/@jest/fake-timers-24.5.0.tgz",
+      "integrity": "sha1-Silni5H9CHYUSlj41G5sYt4CZvA=",
+      "dev": true,
+      "requires": {
+        "@jest/types": "^24.5.0",
+        "@types/node": "*",
+        "jest-message-util": "^24.5.0",
+        "jest-mock": "^24.5.0"
+      }
+    },
+    "@jest/reporters": {
+      "version": "24.5.0",
+      "resolved": "http://registry.npm.taobao.org/@jest/reporters/download/@jest/reporters-24.5.0.tgz",
+      "integrity": "sha1-k2OiENDap0aWiG2cspTrizrZtNk=",
+      "dev": true,
+      "requires": {
+        "@jest/environment": "^24.5.0",
+        "@jest/test-result": "^24.5.0",
+        "@jest/transform": "^24.5.0",
+        "@jest/types": "^24.5.0",
+        "chalk": "^2.0.1",
+        "exit": "^0.1.2",
+        "glob": "^7.1.2",
+        "istanbul-api": "^2.1.1",
+        "istanbul-lib-coverage": "^2.0.2",
+        "istanbul-lib-instrument": "^3.0.1",
+        "istanbul-lib-source-maps": "^3.0.1",
+        "jest-haste-map": "^24.5.0",
+        "jest-resolve": "^24.5.0",
+        "jest-runtime": "^24.5.0",
+        "jest-util": "^24.5.0",
+        "jest-worker": "^24.4.0",
+        "node-notifier": "^5.2.1",
+        "slash": "^2.0.0",
+        "source-map": "^0.6.0",
+        "string-length": "^2.0.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "http://registry.npm.taobao.org/source-map/download/source-map-0.6.1.tgz",
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+          "dev": true
+        }
+      }
+    },
+    "@jest/source-map": {
+      "version": "24.3.0",
+      "resolved": "http://registry.npm.taobao.org/@jest/source-map/download/@jest/source-map-24.3.0.tgz",
+      "integrity": "sha1-Vjvjqk0iTK9l/3ftyVzRyk2mfyg=",
+      "dev": true,
+      "requires": {
+        "callsites": "^3.0.0",
+        "graceful-fs": "^4.1.15",
+        "source-map": "^0.6.0"
+      },
+      "dependencies": {
+        "callsites": {
+          "version": "3.0.0",
+          "resolved": "http://registry.npm.taobao.org/callsites/download/callsites-3.0.0.tgz",
+          "integrity": "sha1-+361abcq16RYEvk/2UMKPkELPdM=",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "http://registry.npm.taobao.org/source-map/download/source-map-0.6.1.tgz",
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+          "dev": true
+        }
+      }
+    },
+    "@jest/test-result": {
+      "version": "24.5.0",
+      "resolved": "http://registry.npm.taobao.org/@jest/test-result/download/@jest/test-result-24.5.0.tgz",
+      "integrity": "sha1-q2b7d0GgSvM2NEMITnLqhIYaU/I=",
+      "dev": true,
+      "requires": {
+        "@jest/console": "^24.3.0",
+        "@jest/types": "^24.5.0",
+        "@types/istanbul-lib-coverage": "^1.1.0"
+      }
+    },
+    "@jest/transform": {
+      "version": "24.5.0",
+      "resolved": "http://registry.npm.taobao.org/@jest/transform/download/@jest/transform-24.5.0.tgz",
+      "integrity": "sha1-Zwn8JtuRjmr2OphfLMPEZLTPmdk=",
+      "dev": true,
+      "requires": {
+        "@babel/core": "^7.1.0",
+        "@jest/types": "^24.5.0",
+        "babel-plugin-istanbul": "^5.1.0",
+        "chalk": "^2.0.1",
+        "convert-source-map": "^1.4.0",
+        "fast-json-stable-stringify": "^2.0.0",
+        "graceful-fs": "^4.1.15",
+        "jest-haste-map": "^24.5.0",
+        "jest-regex-util": "^24.3.0",
+        "jest-util": "^24.5.0",
+        "micromatch": "^3.1.10",
+        "realpath-native": "^1.1.0",
+        "slash": "^2.0.0",
+        "source-map": "^0.6.1",
+        "write-file-atomic": "2.4.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "http://registry.npm.taobao.org/source-map/download/source-map-0.6.1.tgz",
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+          "dev": true
+        }
+      }
+    },
+    "@jest/types": {
+      "version": "24.5.0",
+      "resolved": "http://registry.npm.taobao.org/@jest/types/download/@jest/types-24.5.0.tgz",
+      "integrity": "sha1-/u4hSk0BZ7DKRHKE6VpXqhCz7pU=",
+      "dev": true,
+      "requires": {
+        "@types/istanbul-lib-coverage": "^1.1.0",
+        "@types/yargs": "^12.0.9"
+      }
+    },
     "@marionebl/sander": {
       "version": "0.6.1",
       "resolved": "http://registry.npm.taobao.org/@marionebl/sander/download/@marionebl/sander-0.6.1.tgz",
@@ -1320,6 +1532,60 @@
         "any-observable": "^0.3.0"
       }
     },
+    "@types/babel__core": {
+      "version": "7.1.0",
+      "resolved": "http://registry.npm.taobao.org/@types/babel__core/download/@types/babel__core-7.1.0.tgz",
+      "integrity": "sha1-cQ8kh92k3P0BDKarsrTcc5Q2XFE=",
+      "dev": true,
+      "requires": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "@types/babel__generator": {
+      "version": "7.0.2",
+      "resolved": "http://registry.npm.taobao.org/@types/babel__generator/download/@types/babel__generator-7.0.2.tgz",
+      "integrity": "sha1-0hEqayH61gDXZ0J0KTyF3ODLR/w=",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "@types/babel__template": {
+      "version": "7.0.2",
+      "resolved": "http://registry.npm.taobao.org/@types/babel__template/download/@types/babel__template-7.0.2.tgz",
+      "integrity": "sha1-T/Y9a1Lt2sHee5daUiPtMuzqkwc=",
+      "dev": true,
+      "requires": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "@types/babel__traverse": {
+      "version": "7.0.6",
+      "resolved": "http://registry.npm.taobao.org/@types/babel__traverse/download/@types/babel__traverse-7.0.6.tgz",
+      "integrity": "sha1-Mo3RqPxM/jyEWL6Ud7IZ6hWP17I=",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.3.0"
+      },
+      "dependencies": {
+        "@babel/types": {
+          "version": "7.3.4",
+          "resolved": "http://registry.npm.taobao.org/@babel/types/download/@babel/types-7.3.4.tgz",
+          "integrity": "sha1-v0gurq/7Nnooq7+TV6lJYyNdkO0=",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.11",
+            "to-fast-properties": "^2.0.0"
+          }
+        }
+      }
+    },
     "@types/classnames": {
       "version": "2.2.6",
       "resolved": "http://registry.npm.taobao.org/@types/classnames/download/@types/classnames-2.2.6.tgz",
@@ -1330,6 +1596,12 @@
       "version": "4.7.2",
       "resolved": "http://registry.npm.taobao.org/@types/history/download/@types/history-4.7.2.tgz",
       "integrity": "sha1-DmcOolTVWSQbbus4lPh1SZHnMiA=",
+      "dev": true
+    },
+    "@types/istanbul-lib-coverage": {
+      "version": "1.1.0",
+      "resolved": "http://registry.npm.taobao.org/@types/istanbul-lib-coverage/download/@types/istanbul-lib-coverage-1.1.0.tgz",
+      "integrity": "sha1-LMLKQQUUmDgrQxV8gif+pgNj+Uo=",
       "dev": true
     },
     "@types/node": {
@@ -1384,6 +1656,18 @@
         "@types/react": "*",
         "@types/react-router": "*"
       }
+    },
+    "@types/stack-utils": {
+      "version": "1.0.1",
+      "resolved": "http://registry.npm.taobao.org/@types/stack-utils/download/@types/stack-utils-1.0.1.tgz",
+      "integrity": "sha1-CoUdO9lkmPolwzq3J47TvWXwbD4=",
+      "dev": true
+    },
+    "@types/yargs": {
+      "version": "12.0.9",
+      "resolved": "http://registry.npm.taobao.org/@types/yargs/download/@types/yargs-12.0.9.tgz",
+      "integrity": "sha1-aT52pS9hovHn+0jA7vFnuV6k/9A=",
+      "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
       "version": "1.4.2",
@@ -1631,6 +1915,12 @@
         "through": ">=2.2.7 <3"
       }
     },
+    "abab": {
+      "version": "2.0.0",
+      "resolved": "http://registry.npm.taobao.org/abab/download/abab-2.0.0.tgz",
+      "integrity": "sha1-q6CrTF7uLUx500h9hUUPsjduuw8=",
+      "dev": true
+    },
     "accepts": {
       "version": "1.3.5",
       "resolved": "http://registry.npm.taobao.org/accepts/download/accepts-1.3.5.tgz",
@@ -1656,10 +1946,34 @@
         "acorn": "^5.0.0"
       }
     },
+    "acorn-globals": {
+      "version": "4.3.0",
+      "resolved": "http://registry.npm.taobao.org/acorn-globals/download/acorn-globals-4.3.0.tgz",
+      "integrity": "sha1-47b42jwVUqla5idXH33Wkju1QQM=",
+      "dev": true,
+      "requires": {
+        "acorn": "^6.0.1",
+        "acorn-walk": "^6.0.1"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "6.1.1",
+          "resolved": "http://registry.npm.taobao.org/acorn/download/acorn-6.1.1.tgz",
+          "integrity": "sha1-fSWuBbuK0fm2mRCOEJTs14hK3B8=",
+          "dev": true
+        }
+      }
+    },
     "acorn-jsx": {
       "version": "5.0.1",
       "resolved": "http://registry.npm.taobao.org/acorn-jsx/download/acorn-jsx-5.0.1.tgz",
       "integrity": "sha1-MqBk/ZJUKSFqCbFBECv90YX65A4=",
+      "dev": true
+    },
+    "acorn-walk": {
+      "version": "6.1.1",
+      "resolved": "http://registry.npm.taobao.org/acorn-walk/download/acorn-walk-6.1.1.tgz",
+      "integrity": "sha1-02O2b1+sXwGP+cOh57b44xDMORM=",
       "dev": true
     },
     "ajv": {
@@ -1741,6 +2055,15 @@
         "normalize-path": "^2.1.1"
       }
     },
+    "append-transform": {
+      "version": "1.0.0",
+      "resolved": "http://registry.npm.taobao.org/append-transform/download/append-transform-1.0.0.tgz",
+      "integrity": "sha1-BGpSrlgqIovXL1is++KWfGeHWas=",
+      "dev": true,
+      "requires": {
+        "default-require-extensions": "^2.0.0"
+      }
+    },
     "aproba": {
       "version": "1.2.0",
       "resolved": "http://registry.npm.taobao.org/aproba/download/aproba-1.2.0.tgz",
@@ -1782,6 +2105,18 @@
       "version": "3.1.0",
       "resolved": "http://registry.npm.taobao.org/arr-union/download/arr-union-3.1.0.tgz",
       "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
+      "dev": true
+    },
+    "array-equal": {
+      "version": "1.0.0",
+      "resolved": "http://registry.npm.taobao.org/array-equal/download/array-equal-1.0.0.tgz",
+      "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
+      "dev": true
+    },
+    "array-filter": {
+      "version": "1.0.0",
+      "resolved": "http://registry.npm.taobao.org/array-filter/download/array-filter-1.0.0.tgz",
+      "integrity": "sha1-uveeYubvTCpMC4MSMtr/7CUfnYM=",
       "dev": true
     },
     "array-find-index": {
@@ -1833,11 +2168,31 @@
       "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
       "dev": true
     },
+    "array.prototype.flat": {
+      "version": "1.2.1",
+      "resolved": "http://registry.npm.taobao.org/array.prototype.flat/download/array.prototype.flat-1.2.1.tgz",
+      "integrity": "sha1-gS248CytJNP6tl3WfqvjuJA0lKQ=",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.10.0",
+        "function-bind": "^1.1.1"
+      }
+    },
     "arrify": {
       "version": "1.0.1",
       "resolved": "http://registry.npm.taobao.org/arrify/download/arrify-1.0.1.tgz",
       "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
       "dev": true
+    },
+    "asn1": {
+      "version": "0.2.4",
+      "resolved": "http://registry.npm.taobao.org/asn1/download/asn1-0.2.4.tgz",
+      "integrity": "sha1-jSR136tVO7M+d7VOWeiAu4ziMTY=",
+      "dev": true,
+      "requires": {
+        "safer-buffer": "~2.1.0"
+      }
     },
     "asn1.js": {
       "version": "4.10.1",
@@ -1876,6 +2231,12 @@
         }
       }
     },
+    "assert-plus": {
+      "version": "1.0.0",
+      "resolved": "http://registry.npm.taobao.org/assert-plus/download/assert-plus-1.0.0.tgz",
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+      "dev": true
+    },
     "assign-symbols": {
       "version": "1.0.0",
       "resolved": "http://registry.npm.taobao.org/assign-symbols/download/assign-symbols-1.0.0.tgz",
@@ -1910,6 +2271,18 @@
       "version": "1.0.1",
       "resolved": "http://registry.npm.taobao.org/async-each/download/async-each-1.0.1.tgz",
       "integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0=",
+      "dev": true
+    },
+    "async-limiter": {
+      "version": "1.0.0",
+      "resolved": "http://registry.npm.taobao.org/async-limiter/download/async-limiter-1.0.0.tgz",
+      "integrity": "sha1-ePrtjD0HSrgfIrTphdeehzj3IPg=",
+      "dev": true
+    },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "http://registry.npm.taobao.org/asynckit/download/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
       "dev": true
     },
     "atob": {
@@ -1958,6 +2331,18 @@
           }
         }
       }
+    },
+    "aws-sign2": {
+      "version": "0.7.0",
+      "resolved": "http://registry.npm.taobao.org/aws-sign2/download/aws-sign2-0.7.0.tgz",
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+      "dev": true
+    },
+    "aws4": {
+      "version": "1.8.0",
+      "resolved": "http://registry.npm.taobao.org/aws4/download/aws4-1.8.0.tgz",
+      "integrity": "sha1-8OAD2cqef1nHpQiUXXsu+aBKVC8=",
+      "dev": true
     },
     "axobject-query": {
       "version": "2.0.2",
@@ -2021,6 +2406,34 @@
         }
       }
     },
+    "babel-jest": {
+      "version": "24.5.0",
+      "resolved": "http://registry.npm.taobao.org/babel-jest/download/babel-jest-24.5.0.tgz",
+      "integrity": "sha1-DqBCeJgQwr7JBl98irTcGOHShVk=",
+      "dev": true,
+      "requires": {
+        "@jest/transform": "^24.5.0",
+        "@jest/types": "^24.5.0",
+        "@types/babel__core": "^7.1.0",
+        "babel-plugin-istanbul": "^5.1.0",
+        "babel-preset-jest": "^24.3.0",
+        "chalk": "^2.4.2",
+        "slash": "^2.0.0"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "http://registry.npm.taobao.org/chalk/download/chalk-2.4.2.tgz",
+          "integrity": "sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        }
+      }
+    },
     "babel-loader": {
       "version": "8.0.4",
       "resolved": "http://registry.npm.taobao.org/babel-loader/download/babel-loader-8.0.4.tgz",
@@ -2055,6 +2468,71 @@
         }
       }
     },
+    "babel-plugin-istanbul": {
+      "version": "5.1.1",
+      "resolved": "http://registry.npm.taobao.org/babel-plugin-istanbul/download/babel-plugin-istanbul-5.1.1.tgz",
+      "integrity": "sha1-eYFZDxlW111nYwukbwwiSTWIyJM=",
+      "dev": true,
+      "requires": {
+        "find-up": "^3.0.0",
+        "istanbul-lib-instrument": "^3.0.0",
+        "test-exclude": "^5.0.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "3.0.0",
+          "resolved": "http://registry.npm.taobao.org/find-up/download/find-up-3.0.0.tgz",
+          "integrity": "sha1-SRafHXmTQwZG2mHsxa41XCHJe3M=",
+          "dev": true,
+          "requires": {
+            "locate-path": "^3.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "3.0.0",
+          "resolved": "http://registry.npm.taobao.org/locate-path/download/locate-path-3.0.0.tgz",
+          "integrity": "sha1-2+w7OrdZdYBxtY/ln8QYca8hQA4=",
+          "dev": true,
+          "requires": {
+            "p-locate": "^3.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.2.0",
+          "resolved": "http://registry.npm.taobao.org/p-limit/download/p-limit-2.2.0.tgz",
+          "integrity": "sha1-QXyZQeYCepq8ulCS3SkE4lW1+8I=",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "3.0.0",
+          "resolved": "http://registry.npm.taobao.org/p-locate/download/p-locate-3.0.0.tgz",
+          "integrity": "sha1-Mi1poFwCZLJZl9n0DNiokasAZKQ=",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.0.0"
+          }
+        },
+        "p-try": {
+          "version": "2.0.0",
+          "resolved": "http://registry.npm.taobao.org/p-try/download/p-try-2.0.0.tgz",
+          "integrity": "sha1-hQgLuHxkaI+keZb+j3376CEXYLE=",
+          "dev": true
+        }
+      }
+    },
+    "babel-plugin-jest-hoist": {
+      "version": "24.3.0",
+      "resolved": "http://registry.npm.taobao.org/babel-plugin-jest-hoist/download/babel-plugin-jest-hoist-24.3.0.tgz",
+      "integrity": "sha1-8ugpUpRvbkC7CnXSZqN5DYVMi1s=",
+      "dev": true,
+      "requires": {
+        "@types/babel__traverse": "^7.0.6"
+      }
+    },
     "babel-plugin-no-debugging": {
       "version": "1.3.1",
       "resolved": "http://registry.npm.taobao.org/babel-plugin-no-debugging/download/babel-plugin-no-debugging-1.3.1.tgz",
@@ -2081,6 +2559,16 @@
           "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg=",
           "dev": true
         }
+      }
+    },
+    "babel-preset-jest": {
+      "version": "24.3.0",
+      "resolved": "http://registry.npm.taobao.org/babel-preset-jest/download/babel-preset-jest-24.3.0.tgz",
+      "integrity": "sha1-24hJfhiGnxWyTZwOVH2OCrlQeW0=",
+      "dev": true,
+      "requires": {
+        "@babel/plugin-syntax-object-rest-spread": "^7.0.0",
+        "babel-plugin-jest-hoist": "^24.3.0"
       }
     },
     "babel-runtime": {
@@ -2171,6 +2659,15 @@
       "resolved": "http://registry.npm.taobao.org/batch/download/batch-0.6.1.tgz",
       "integrity": "sha1-3DQxT05nkxgJP8dgJyUl+UvyXBY=",
       "dev": true
+    },
+    "bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "resolved": "http://registry.npm.taobao.org/bcrypt-pbkdf/download/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+      "dev": true,
+      "requires": {
+        "tweetnacl": "^0.14.3"
+      }
     },
     "big.js": {
       "version": "3.2.0",
@@ -2279,6 +2776,29 @@
       "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=",
       "dev": true
     },
+    "browser-process-hrtime": {
+      "version": "0.1.3",
+      "resolved": "http://registry.npm.taobao.org/browser-process-hrtime/download/browser-process-hrtime-0.1.3.tgz",
+      "integrity": "sha1-YW8A+u8d9+wbW/nP4r3DFw8mx7Q=",
+      "dev": true
+    },
+    "browser-resolve": {
+      "version": "1.11.3",
+      "resolved": "http://registry.npm.taobao.org/browser-resolve/download/browser-resolve-1.11.3.tgz",
+      "integrity": "sha1-m3y7PQ9RDky4a9vXlhJNKLWJCvY=",
+      "dev": true,
+      "requires": {
+        "resolve": "1.1.7"
+      },
+      "dependencies": {
+        "resolve": {
+          "version": "1.1.7",
+          "resolved": "http://registry.npm.taobao.org/resolve/download/resolve-1.1.7.tgz",
+          "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
+          "dev": true
+        }
+      }
+    },
     "browserify-aes": {
       "version": "1.2.0",
       "resolved": "http://registry.npm.taobao.org/browserify-aes/download/browserify-aes-1.2.0.tgz",
@@ -2359,6 +2879,15 @@
         "caniuse-lite": "^1.0.30000899",
         "electron-to-chromium": "^1.3.82",
         "node-releases": "^1.0.1"
+      }
+    },
+    "bser": {
+      "version": "2.0.0",
+      "resolved": "http://registry.npm.taobao.org/bser/download/bser-2.0.0.tgz",
+      "integrity": "sha1-mseNPtXZFYBP2HrLFYvHlxR6Fxk=",
+      "dev": true,
+      "requires": {
+        "node-int64": "^0.4.0"
       }
     },
     "buffer": {
@@ -2512,6 +3041,21 @@
       "integrity": "sha1-dV1RgdSwBuWitZsf+gXQoEcAOfU=",
       "dev": true
     },
+    "capture-exit": {
+      "version": "1.2.0",
+      "resolved": "http://registry.npm.taobao.org/capture-exit/download/capture-exit-1.2.0.tgz",
+      "integrity": "sha1-HF/MSJ/QqwDU8ax64QcuMXP7q28=",
+      "dev": true,
+      "requires": {
+        "rsvp": "^3.3.3"
+      }
+    },
+    "caseless": {
+      "version": "0.12.0",
+      "resolved": "http://registry.npm.taobao.org/caseless/download/caseless-0.12.0.tgz",
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+      "dev": true
+    },
     "chain-get": {
       "version": "1.0.1",
       "resolved": "http://registry.npm.taobao.org/chain-get/download/chain-get-1.0.1.tgz",
@@ -2552,6 +3096,62 @@
       "resolved": "http://registry.npm.taobao.org/chardet/download/chardet-0.7.0.tgz",
       "integrity": "sha1-kAlISfCTfy7twkJdDSip5fDLrZ4=",
       "dev": true
+    },
+    "cheerio": {
+      "version": "1.0.0-rc.2",
+      "resolved": "http://registry.npm.taobao.org/cheerio/download/cheerio-1.0.0-rc.2.tgz",
+      "integrity": "sha1-S59TqBsn5NXawxwP/Qz6A8xoMNs=",
+      "dev": true,
+      "requires": {
+        "css-select": "~1.2.0",
+        "dom-serializer": "~0.1.0",
+        "entities": "~1.1.1",
+        "htmlparser2": "^3.9.1",
+        "lodash": "^4.15.0",
+        "parse5": "^3.0.1"
+      },
+      "dependencies": {
+        "domelementtype": {
+          "version": "1.3.1",
+          "resolved": "http://registry.npm.taobao.org/domelementtype/download/domelementtype-1.3.1.tgz",
+          "integrity": "sha1-0EjESzew0Qp/Kj1f7j9DM9eQSB8=",
+          "dev": true
+        },
+        "domhandler": {
+          "version": "2.4.2",
+          "resolved": "http://registry.npm.taobao.org/domhandler/download/domhandler-2.4.2.tgz",
+          "integrity": "sha1-iAUJfpM9ZehVRvcm1g9euItE+AM=",
+          "dev": true,
+          "requires": {
+            "domelementtype": "1"
+          }
+        },
+        "htmlparser2": {
+          "version": "3.10.1",
+          "resolved": "http://registry.npm.taobao.org/htmlparser2/download/htmlparser2-3.10.1.tgz",
+          "integrity": "sha1-vWedw/WYl7ajS7EHSchVu1OpOS8=",
+          "dev": true,
+          "requires": {
+            "domelementtype": "^1.3.1",
+            "domhandler": "^2.3.0",
+            "domutils": "^1.5.1",
+            "entities": "^1.1.1",
+            "inherits": "^2.0.1",
+            "readable-stream": "^3.1.1"
+          }
+        },
+        "readable-stream": {
+          "version": "3.2.0",
+          "resolved": "http://registry.npm.taobao.org/readable-stream/download/readable-stream-3.2.0.tgz",
+          "integrity": "sha1-3hfyKYZMEgqfVpRXVuTzLEBFJF0=",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
+      }
     },
     "chokidar": {
       "version": "2.0.4",
@@ -2741,6 +3341,12 @@
         "shallow-clone": "^1.0.0"
       }
     },
+    "co": {
+      "version": "4.6.0",
+      "resolved": "http://registry.npm.taobao.org/co/download/co-4.6.0.tgz",
+      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+      "dev": true
+    },
     "code-point-at": {
       "version": "1.1.0",
       "resolved": "http://registry.npm.taobao.org/code-point-at/download/code-point-at-1.1.0.tgz",
@@ -2778,6 +3384,15 @@
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
     },
+    "combined-stream": {
+      "version": "1.0.7",
+      "resolved": "http://registry.npm.taobao.org/combined-stream/download/combined-stream-1.0.7.tgz",
+      "integrity": "sha1-LR0kMXr7ir6V1tLAsHtXgTU52Cg=",
+      "dev": true,
+      "requires": {
+        "delayed-stream": "~1.0.0"
+      }
+    },
     "commander": {
       "version": "2.17.1",
       "resolved": "http://registry.npm.taobao.org/commander/download/commander-2.17.1.tgz",
@@ -2810,6 +3425,12 @@
         "array-ify": "^1.0.0",
         "dot-prop": "^3.0.0"
       }
+    },
+    "compare-versions": {
+      "version": "3.4.0",
+      "resolved": "http://registry.npm.taobao.org/compare-versions/download/compare-versions-3.4.0.tgz",
+      "integrity": "sha1-4HR99cnLfwVNbT3D4dvERPnpKyY=",
+      "dev": true
     },
     "component-emitter": {
       "version": "1.2.1",
@@ -3147,6 +3768,21 @@
       "integrity": "sha1-yBSQPkViM3GgR3tAEJqq++6t27Q=",
       "dev": true
     },
+    "cssom": {
+      "version": "0.3.6",
+      "resolved": "http://registry.npm.taobao.org/cssom/download/cssom-0.3.6.tgz",
+      "integrity": "sha1-+FIGzuBO+oQfPFmCp0uparINZa0=",
+      "dev": true
+    },
+    "cssstyle": {
+      "version": "1.2.1",
+      "resolved": "http://registry.npm.taobao.org/cssstyle/download/cssstyle-1.2.1.tgz",
+      "integrity": "sha1-Os6ydZ6vUUrBohYo1yPWBDqBlJU=",
+      "dev": true,
+      "requires": {
+        "cssom": "0.3.x"
+      }
+    },
     "csstype": {
       "version": "2.5.7",
       "resolved": "http://registry.npm.taobao.org/csstype/download/csstype-2.5.7.tgz",
@@ -3190,6 +3826,39 @@
       "dev": true,
       "requires": {
         "number-is-nan": "^1.0.0"
+      }
+    },
+    "dashdash": {
+      "version": "1.14.1",
+      "resolved": "http://registry.npm.taobao.org/dashdash/download/dashdash-1.14.1.tgz",
+      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "^1.0.0"
+      }
+    },
+    "data-urls": {
+      "version": "1.1.0",
+      "resolved": "http://registry.npm.taobao.org/data-urls/download/data-urls-1.1.0.tgz",
+      "integrity": "sha1-Fe4Fgrql4iu1nHcUDaj5x2lju/4=",
+      "dev": true,
+      "requires": {
+        "abab": "^2.0.0",
+        "whatwg-mimetype": "^2.2.0",
+        "whatwg-url": "^7.0.0"
+      },
+      "dependencies": {
+        "whatwg-url": {
+          "version": "7.0.0",
+          "resolved": "http://registry.npm.taobao.org/whatwg-url/download/whatwg-url-7.0.0.tgz",
+          "integrity": "sha1-/ekm+lSlmfOt+C3/Jan3vgLcbt0=",
+          "dev": true,
+          "requires": {
+            "lodash.sortby": "^4.7.0",
+            "tr46": "^1.0.1",
+            "webidl-conversions": "^4.0.2"
+          }
+        }
       }
     },
     "date-fns": {
@@ -3271,6 +3940,15 @@
         "ip-regex": "^2.1.0"
       }
     },
+    "default-require-extensions": {
+      "version": "2.0.0",
+      "resolved": "http://registry.npm.taobao.org/default-require-extensions/download/default-require-extensions-2.0.0.tgz",
+      "integrity": "sha1-9fj7sYp9bVCyH2QfZJ67Uiz+JPc=",
+      "dev": true,
+      "requires": {
+        "strip-bom": "^3.0.0"
+      }
+    },
     "define-properties": {
       "version": "1.1.3",
       "resolved": "http://registry.npm.taobao.org/define-properties/download/define-properties-1.1.3.tgz",
@@ -3335,6 +4013,12 @@
         "rimraf": "^2.2.8"
       }
     },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "http://registry.npm.taobao.org/delayed-stream/download/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "dev": true
+    },
     "depd": {
       "version": "1.1.2",
       "resolved": "http://registry.npm.taobao.org/depd/download/depd-1.1.2.tgz",
@@ -3357,10 +4041,22 @@
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
       "dev": true
     },
+    "detect-newline": {
+      "version": "2.1.0",
+      "resolved": "http://registry.npm.taobao.org/detect-newline/download/detect-newline-2.1.0.tgz",
+      "integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I=",
+      "dev": true
+    },
     "detect-node": {
       "version": "2.0.4",
       "resolved": "http://registry.npm.taobao.org/detect-node/download/detect-node-2.0.4.tgz",
       "integrity": "sha1-AU7o+PZpxcWAI9pkuBecCDooxGw=",
+      "dev": true
+    },
+    "diff-sequences": {
+      "version": "24.3.0",
+      "resolved": "http://registry.npm.taobao.org/diff-sequences/download/diff-sequences-24.3.0.tgz",
+      "integrity": "sha1-DyDood8avdr02cImaAlS5kEYuXU=",
       "dev": true
     },
     "diffie-hellman": {
@@ -3373,6 +4069,12 @@
         "miller-rabin": "^4.0.0",
         "randombytes": "^2.0.0"
       }
+    },
+    "discontinuous-range": {
+      "version": "1.0.0",
+      "resolved": "http://registry.npm.taobao.org/discontinuous-range/download/discontinuous-range-1.0.0.tgz",
+      "integrity": "sha1-44Mx8IRLukm5qctxx3FYWqsbxlo=",
+      "dev": true
     },
     "dns-equal": {
       "version": "1.0.0",
@@ -3447,6 +4149,15 @@
       "integrity": "sha1-V4VY7yO++sBDoauw2wdjVQk5NHk=",
       "dev": true
     },
+    "domexception": {
+      "version": "1.0.1",
+      "resolved": "http://registry.npm.taobao.org/domexception/download/domexception-1.0.1.tgz",
+      "integrity": "sha1-k3RCZEymoxJh7zbj7Gd/6AVYLJA=",
+      "dev": true,
+      "requires": {
+        "webidl-conversions": "^4.0.2"
+      }
+    },
     "domhandler": {
       "version": "2.1.0",
       "resolved": "http://registry.npm.taobao.org/domhandler/download/domhandler-2.1.0.tgz",
@@ -3485,6 +4196,16 @@
         "inherits": "^2.0.1",
         "readable-stream": "^2.0.0",
         "stream-shift": "^1.0.0"
+      }
+    },
+    "ecc-jsbn": {
+      "version": "0.1.2",
+      "resolved": "http://registry.npm.taobao.org/ecc-jsbn/download/ecc-jsbn-0.1.2.tgz",
+      "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+      "dev": true,
+      "requires": {
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.1.0"
       }
     },
     "ee-first": {
@@ -3563,6 +4284,98 @@
       "resolved": "http://registry.npm.taobao.org/entities/download/entities-1.1.2.tgz",
       "integrity": "sha1-vfpzUplmTfr9NFKe1PhSKidf6lY=",
       "dev": true
+    },
+    "enzyme": {
+      "version": "3.9.0",
+      "resolved": "http://registry.npm.taobao.org/enzyme/download/enzyme-3.9.0.tgz",
+      "integrity": "sha1-K0kfBsqWbrVrZRAGjHiUp+C+OQk=",
+      "dev": true,
+      "requires": {
+        "array.prototype.flat": "^1.2.1",
+        "cheerio": "^1.0.0-rc.2",
+        "function.prototype.name": "^1.1.0",
+        "has": "^1.0.3",
+        "html-element-map": "^1.0.0",
+        "is-boolean-object": "^1.0.0",
+        "is-callable": "^1.1.4",
+        "is-number-object": "^1.0.3",
+        "is-regex": "^1.0.4",
+        "is-string": "^1.0.4",
+        "is-subset": "^0.1.1",
+        "lodash.escape": "^4.0.1",
+        "lodash.isequal": "^4.5.0",
+        "object-inspect": "^1.6.0",
+        "object-is": "^1.0.1",
+        "object.assign": "^4.1.0",
+        "object.entries": "^1.0.4",
+        "object.values": "^1.0.4",
+        "raf": "^3.4.0",
+        "rst-selector-parser": "^2.2.3",
+        "string.prototype.trim": "^1.1.2"
+      }
+    },
+    "enzyme-adapter-react-16": {
+      "version": "1.11.0",
+      "resolved": "http://registry.npm.taobao.org/enzyme-adapter-react-16/download/enzyme-adapter-react-16-1.11.0.tgz",
+      "integrity": "sha1-z5xg6g2YvnE+ksxxAO+Z3SnF8z8=",
+      "dev": true,
+      "requires": {
+        "enzyme-adapter-utils": "^1.10.1",
+        "object.assign": "^4.1.0",
+        "object.values": "^1.1.0",
+        "prop-types": "^15.7.2",
+        "react-is": "^16.8.4",
+        "react-test-renderer": "^16.0.0-0",
+        "semver": "^5.6.0"
+      },
+      "dependencies": {
+        "prop-types": {
+          "version": "15.7.2",
+          "resolved": "http://registry.npm.taobao.org/prop-types/download/prop-types-15.7.2.tgz",
+          "integrity": "sha1-UsQedbjIfnK52TYOAga5ncv/psU=",
+          "dev": true,
+          "requires": {
+            "loose-envify": "^1.4.0",
+            "object-assign": "^4.1.1",
+            "react-is": "^16.8.1"
+          }
+        }
+      }
+    },
+    "enzyme-adapter-utils": {
+      "version": "1.10.1",
+      "resolved": "http://registry.npm.taobao.org/enzyme-adapter-utils/download/enzyme-adapter-utils-1.10.1.tgz",
+      "integrity": "sha1-WCZO+hmnvv2/lk+3mBoQilRSrJY=",
+      "dev": true,
+      "requires": {
+        "function.prototype.name": "^1.1.0",
+        "object.assign": "^4.1.0",
+        "object.fromentries": "^2.0.0",
+        "prop-types": "^15.7.2",
+        "semver": "^5.6.0"
+      },
+      "dependencies": {
+        "prop-types": {
+          "version": "15.7.2",
+          "resolved": "http://registry.npm.taobao.org/prop-types/download/prop-types-15.7.2.tgz",
+          "integrity": "sha1-UsQedbjIfnK52TYOAga5ncv/psU=",
+          "dev": true,
+          "requires": {
+            "loose-envify": "^1.4.0",
+            "object-assign": "^4.1.1",
+            "react-is": "^16.8.1"
+          }
+        }
+      }
+    },
+    "enzyme-to-json": {
+      "version": "3.3.5",
+      "resolved": "http://registry.npm.taobao.org/enzyme-to-json/download/enzyme-to-json-3.3.5.tgz",
+      "integrity": "sha1-+OuCvT1ZQcnYvG/ZFAAwd30X0K8=",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.4"
+      }
     },
     "errno": {
       "version": "0.1.7",
@@ -3659,6 +4472,34 @@
       "resolved": "http://registry.npm.taobao.org/escape-string-regexp/download/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true
+    },
+    "escodegen": {
+      "version": "1.11.1",
+      "resolved": "http://registry.npm.taobao.org/escodegen/download/escodegen-1.11.1.tgz",
+      "integrity": "sha1-xIX/jWtM24nif0qFbpHxGEAcpRA=",
+      "dev": true,
+      "requires": {
+        "esprima": "^3.1.3",
+        "estraverse": "^4.2.0",
+        "esutils": "^2.0.2",
+        "optionator": "^0.8.1",
+        "source-map": "~0.6.1"
+      },
+      "dependencies": {
+        "esprima": {
+          "version": "3.1.3",
+          "resolved": "http://registry.npm.taobao.org/esprima/download/esprima-3.1.3.tgz",
+          "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "http://registry.npm.taobao.org/source-map/download/source-map-0.6.1.tgz",
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+          "dev": true,
+          "optional": true
+        }
+      }
     },
     "eslint": {
       "version": "5.15.1",
@@ -4109,6 +4950,12 @@
         "safe-buffer": "^5.1.1"
       }
     },
+    "exec-sh": {
+      "version": "0.3.2",
+      "resolved": "http://registry.npm.taobao.org/exec-sh/download/exec-sh-0.3.2.tgz",
+      "integrity": "sha1-ZzjeLrfI5nHQNmrqCw24xvfXORs=",
+      "dev": true
+    },
     "execa": {
       "version": "1.0.0",
       "resolved": "http://registry.npm.taobao.org/execa/download/execa-1.0.0.tgz",
@@ -4123,6 +4970,12 @@
         "signal-exit": "^3.0.0",
         "strip-eof": "^1.0.0"
       }
+    },
+    "exit": {
+      "version": "0.1.2",
+      "resolved": "http://registry.npm.taobao.org/exit/download/exit-0.1.2.tgz",
+      "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
+      "dev": true
     },
     "expand-brackets": {
       "version": "2.1.4",
@@ -4157,6 +5010,20 @@
             "is-extendable": "^0.1.0"
           }
         }
+      }
+    },
+    "expect": {
+      "version": "24.5.0",
+      "resolved": "http://registry.npm.taobao.org/expect/download/expect-24.5.0.tgz",
+      "integrity": "sha1-SS+w34N42EdMyEuCd3awafRilO0=",
+      "dev": true,
+      "requires": {
+        "@jest/types": "^24.5.0",
+        "ansi-styles": "^3.2.0",
+        "jest-get-type": "^24.3.0",
+        "jest-matcher-utils": "^24.5.0",
+        "jest-message-util": "^24.5.0",
+        "jest-regex-util": "^24.3.0"
       }
     },
     "express": {
@@ -4319,6 +5186,12 @@
         }
       }
     },
+    "extsprintf": {
+      "version": "1.3.0",
+      "resolved": "http://registry.npm.taobao.org/extsprintf/download/extsprintf-1.3.0.tgz",
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+      "dev": true
+    },
     "fast-deep-equal": {
       "version": "2.0.1",
       "resolved": "http://registry.npm.taobao.org/fast-deep-equal/download/fast-deep-equal-2.0.1.tgz",
@@ -4356,6 +5229,15 @@
       "dev": true,
       "requires": {
         "websocket-driver": ">=0.5.1"
+      }
+    },
+    "fb-watchman": {
+      "version": "2.0.0",
+      "resolved": "http://registry.npm.taobao.org/fb-watchman/download/fb-watchman-2.0.0.tgz",
+      "integrity": "sha1-VOmr99+i8mzZsWNsWIwa/AXeXVg=",
+      "dev": true,
+      "requires": {
+        "bser": "^2.0.0"
       }
     },
     "figgy-pudding": {
@@ -4403,6 +5285,16 @@
             "ajv-keywords": "^3.1.0"
           }
         }
+      }
+    },
+    "fileset": {
+      "version": "2.0.3",
+      "resolved": "http://registry.npm.taobao.org/fileset/download/fileset-2.0.3.tgz",
+      "integrity": "sha1-jnVIqW08wjJ+5eZ0FocjozO7oqA=",
+      "dev": true,
+      "requires": {
+        "glob": "^7.0.3",
+        "minimatch": "^3.0.3"
       }
     },
     "fill-range": {
@@ -4552,6 +5444,23 @@
       "dev": true,
       "requires": {
         "for-in": "^1.0.1"
+      }
+    },
+    "forever-agent": {
+      "version": "0.6.1",
+      "resolved": "http://registry.npm.taobao.org/forever-agent/download/forever-agent-0.6.1.tgz",
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+      "dev": true
+    },
+    "form-data": {
+      "version": "2.3.3",
+      "resolved": "http://registry.npm.taobao.org/form-data/download/form-data-2.3.3.tgz",
+      "integrity": "sha1-3M5SwF9kTymManq5Nr1yTO/786Y=",
+      "dev": true,
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.6",
+        "mime-types": "^2.1.12"
       }
     },
     "forwarded": {
@@ -5219,6 +6128,17 @@
       "integrity": "sha1-pWiZ0+o8m6uHS7l3O3xe3pL0iV0=",
       "dev": true
     },
+    "function.prototype.name": {
+      "version": "1.1.0",
+      "resolved": "http://registry.npm.taobao.org/function.prototype.name/download/function.prototype.name-1.1.0.tgz",
+      "integrity": "sha1-i9djzAr4YKhZzF1JOE10uTLNIyc=",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.2",
+        "function-bind": "^1.1.1",
+        "is-callable": "^1.1.3"
+      }
+    },
     "functional-red-black-tree": {
       "version": "1.0.1",
       "resolved": "http://registry.npm.taobao.org/functional-red-black-tree/download/functional-red-black-tree-1.0.1.tgz",
@@ -5268,6 +6188,15 @@
       "resolved": "http://registry.npm.taobao.org/get-value/download/get-value-2.0.6.tgz",
       "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
       "dev": true
+    },
+    "getpass": {
+      "version": "0.1.7",
+      "resolved": "http://registry.npm.taobao.org/getpass/download/getpass-0.1.7.tgz",
+      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "^1.0.0"
+      }
     },
     "git-raw-commits": {
       "version": "1.3.6",
@@ -5390,11 +6319,62 @@
       "integrity": "sha1-/7cD4QZuig7qpMi4C6klPu77+wA=",
       "dev": true
     },
+    "growly": {
+      "version": "1.3.0",
+      "resolved": "http://registry.npm.taobao.org/growly/download/growly-1.3.0.tgz",
+      "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
+      "dev": true
+    },
     "handle-thing": {
       "version": "2.0.0",
       "resolved": "http://registry.npm.taobao.org/handle-thing/download/handle-thing-2.0.0.tgz",
       "integrity": "sha1-DgOWlf9QyT/CiFV9aW88HcZ3Z1Q=",
       "dev": true
+    },
+    "handlebars": {
+      "version": "4.1.0",
+      "resolved": "http://registry.npm.taobao.org/handlebars/download/handlebars-4.1.0.tgz",
+      "integrity": "sha1-DWpvNP8fY87OyEI6pBaYJ794fDo=",
+      "dev": true,
+      "requires": {
+        "async": "^2.5.0",
+        "optimist": "^0.6.1",
+        "source-map": "^0.6.1",
+        "uglify-js": "^3.1.4"
+      },
+      "dependencies": {
+        "async": {
+          "version": "2.6.2",
+          "resolved": "http://registry.npm.taobao.org/async/download/async-2.6.2.tgz",
+          "integrity": "sha1-GDMOp+bjE4h/XS8qkEusb+TdU4E=",
+          "dev": true,
+          "requires": {
+            "lodash": "^4.17.11"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "http://registry.npm.taobao.org/source-map/download/source-map-0.6.1.tgz",
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+          "dev": true
+        }
+      }
+    },
+    "har-schema": {
+      "version": "2.0.0",
+      "resolved": "http://registry.npm.taobao.org/har-schema/download/har-schema-2.0.0.tgz",
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+      "dev": true
+    },
+    "har-validator": {
+      "version": "5.1.3",
+      "resolved": "http://registry.npm.taobao.org/har-validator/download/har-validator-5.1.3.tgz",
+      "integrity": "sha1-HvievT5JllV2de7ZiTEQ3DUPoIA=",
+      "dev": true,
+      "requires": {
+        "ajv": "^6.5.5",
+        "har-schema": "^2.0.0"
+      }
     },
     "has": {
       "version": "1.0.3",
@@ -5564,6 +6544,24 @@
         "obuf": "^1.0.0",
         "readable-stream": "^2.0.1",
         "wbuf": "^1.1.0"
+      }
+    },
+    "html-element-map": {
+      "version": "1.0.0",
+      "resolved": "http://registry.npm.taobao.org/html-element-map/download/html-element-map-1.0.0.tgz",
+      "integrity": "sha1-GaQZQCJRU+zf6tdPhQkVT/HNwYs=",
+      "dev": true,
+      "requires": {
+        "array-filter": "^1.0.0"
+      }
+    },
+    "html-encoding-sniffer": {
+      "version": "1.0.2",
+      "resolved": "http://registry.npm.taobao.org/html-encoding-sniffer/download/html-encoding-sniffer-1.0.2.tgz",
+      "integrity": "sha1-5w2EuU2lOqN14R/jo1G+ZkLKRvg=",
+      "dev": true,
+      "requires": {
+        "whatwg-encoding": "^1.0.1"
       }
     },
     "html-entities": {
@@ -5778,6 +6776,17 @@
         "is-glob": "^4.0.0",
         "lodash": "^4.17.11",
         "micromatch": "^3.1.10"
+      }
+    },
+    "http-signature": {
+      "version": "1.2.0",
+      "resolved": "http://registry.npm.taobao.org/http-signature/download/http-signature-1.2.0.tgz",
+      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
       }
     },
     "https-browserify": {
@@ -6154,6 +7163,12 @@
         "binary-extensions": "^1.0.0"
       }
     },
+    "is-boolean-object": {
+      "version": "1.0.0",
+      "resolved": "http://registry.npm.taobao.org/is-boolean-object/download/is-boolean-object-1.0.0.tgz",
+      "integrity": "sha1-mPiygDBoQhmpXzdc+9iM40Bd/5M=",
+      "dev": true
+    },
     "is-buffer": {
       "version": "1.1.6",
       "resolved": "http://registry.npm.taobao.org/is-buffer/download/is-buffer-1.1.6.tgz",
@@ -6259,6 +7274,12 @@
       "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
       "dev": true
     },
+    "is-generator-fn": {
+      "version": "2.0.0",
+      "resolved": "http://registry.npm.taobao.org/is-generator-fn/download/is-generator-fn-2.0.0.tgz",
+      "integrity": "sha1-A4wxt3RwlkG9pnix8GpOMifBCz4=",
+      "dev": true
+    },
     "is-glob": {
       "version": "4.0.0",
       "resolved": "http://registry.npm.taobao.org/is-glob/download/is-glob-4.0.0.tgz",
@@ -6293,6 +7314,12 @@
           }
         }
       }
+    },
+    "is-number-object": {
+      "version": "1.0.3",
+      "resolved": "http://registry.npm.taobao.org/is-number-object/download/is-number-object-1.0.3.tgz",
+      "integrity": "sha1-8mWrian0RQNO9q/xWo8AsA9VF5k=",
+      "dev": true
     },
     "is-obj": {
       "version": "1.0.1",
@@ -6375,6 +7402,18 @@
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
       "dev": true
     },
+    "is-string": {
+      "version": "1.0.4",
+      "resolved": "http://registry.npm.taobao.org/is-string/download/is-string-1.0.4.tgz",
+      "integrity": "sha1-zDqbaYV9Yh6WNyWiTK7shzuCbmQ=",
+      "dev": true
+    },
+    "is-subset": {
+      "version": "0.1.1",
+      "resolved": "http://registry.npm.taobao.org/is-subset/download/is-subset-0.1.1.tgz",
+      "integrity": "sha1-ilkRfZMt4d4A8kX83TnOQ/HpOaY=",
+      "dev": true
+    },
     "is-symbol": {
       "version": "1.0.2",
       "resolved": "http://registry.npm.taobao.org/is-symbol/download/is-symbol-1.0.2.tgz",
@@ -6392,6 +7431,12 @@
       "requires": {
         "text-extensions": "^1.0.0"
       }
+    },
+    "is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "http://registry.npm.taobao.org/is-typedarray/download/is-typedarray-1.0.0.tgz",
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "dev": true
     },
     "is-whitespace-character": {
       "version": "1.0.2",
@@ -6435,6 +7480,621 @@
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
       "dev": true
     },
+    "isstream": {
+      "version": "0.1.2",
+      "resolved": "http://registry.npm.taobao.org/isstream/download/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+      "dev": true
+    },
+    "istanbul-api": {
+      "version": "2.1.1",
+      "resolved": "http://registry.npm.taobao.org/istanbul-api/download/istanbul-api-2.1.1.tgz",
+      "integrity": "sha1-GUt3P22cvJmpJYRGhIsPmIlRxNA=",
+      "dev": true,
+      "requires": {
+        "async": "^2.6.1",
+        "compare-versions": "^3.2.1",
+        "fileset": "^2.0.3",
+        "istanbul-lib-coverage": "^2.0.3",
+        "istanbul-lib-hook": "^2.0.3",
+        "istanbul-lib-instrument": "^3.1.0",
+        "istanbul-lib-report": "^2.0.4",
+        "istanbul-lib-source-maps": "^3.0.2",
+        "istanbul-reports": "^2.1.1",
+        "js-yaml": "^3.12.0",
+        "make-dir": "^1.3.0",
+        "minimatch": "^3.0.4",
+        "once": "^1.4.0"
+      },
+      "dependencies": {
+        "async": {
+          "version": "2.6.2",
+          "resolved": "http://registry.npm.taobao.org/async/download/async-2.6.2.tgz",
+          "integrity": "sha1-GDMOp+bjE4h/XS8qkEusb+TdU4E=",
+          "dev": true,
+          "requires": {
+            "lodash": "^4.17.11"
+          }
+        }
+      }
+    },
+    "istanbul-lib-coverage": {
+      "version": "2.0.3",
+      "resolved": "http://registry.npm.taobao.org/istanbul-lib-coverage/download/istanbul-lib-coverage-2.0.3.tgz",
+      "integrity": "sha1-C4keWtQjEsK5SIVU9gN5X5oiEbo=",
+      "dev": true
+    },
+    "istanbul-lib-hook": {
+      "version": "2.0.3",
+      "resolved": "http://registry.npm.taobao.org/istanbul-lib-hook/download/istanbul-lib-hook-2.0.3.tgz",
+      "integrity": "sha1-4OWB5GHGEb5dDl7zHF8BCXWZFvs=",
+      "dev": true,
+      "requires": {
+        "append-transform": "^1.0.0"
+      }
+    },
+    "istanbul-lib-instrument": {
+      "version": "3.1.0",
+      "resolved": "http://registry.npm.taobao.org/istanbul-lib-instrument/download/istanbul-lib-instrument-3.1.0.tgz",
+      "integrity": "sha1-orVISn1EXx8xHpMZCBP6Vt+2KXE=",
+      "dev": true,
+      "requires": {
+        "@babel/generator": "^7.0.0",
+        "@babel/parser": "^7.0.0",
+        "@babel/template": "^7.0.0",
+        "@babel/traverse": "^7.0.0",
+        "@babel/types": "^7.0.0",
+        "istanbul-lib-coverage": "^2.0.3",
+        "semver": "^5.5.0"
+      }
+    },
+    "istanbul-lib-report": {
+      "version": "2.0.4",
+      "resolved": "http://registry.npm.taobao.org/istanbul-lib-report/download/istanbul-lib-report-2.0.4.tgz",
+      "integrity": "sha1-v9Mk7gwE9ZEZy08H2rFX0J8k1+Q=",
+      "dev": true,
+      "requires": {
+        "istanbul-lib-coverage": "^2.0.3",
+        "make-dir": "^1.3.0",
+        "supports-color": "^6.0.0"
+      },
+      "dependencies": {
+        "supports-color": {
+          "version": "6.1.0",
+          "resolved": "http://registry.npm.taobao.org/supports-color/download/supports-color-6.1.0.tgz",
+          "integrity": "sha1-B2Srxpxj1ayELdSGfo0CXogN+PM=",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
+    "istanbul-lib-source-maps": {
+      "version": "3.0.2",
+      "resolved": "http://registry.npm.taobao.org/istanbul-lib-source-maps/download/istanbul-lib-source-maps-3.0.2.tgz",
+      "integrity": "sha1-8egXIpqRRuhCSijl1puiIP2jQVY=",
+      "dev": true,
+      "requires": {
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^2.0.3",
+        "make-dir": "^1.3.0",
+        "rimraf": "^2.6.2",
+        "source-map": "^0.6.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "http://registry.npm.taobao.org/debug/download/debug-4.1.1.tgz",
+          "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "http://registry.npm.taobao.org/ms/download/ms-2.1.1.tgz",
+          "integrity": "sha1-MKWGTrPrsKZvLr5tcnrwagnYbgo=",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "http://registry.npm.taobao.org/source-map/download/source-map-0.6.1.tgz",
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+          "dev": true
+        }
+      }
+    },
+    "istanbul-reports": {
+      "version": "2.1.1",
+      "resolved": "http://registry.npm.taobao.org/istanbul-reports/download/istanbul-reports-2.1.1.tgz",
+      "integrity": "sha1-cu8WtOy5pKe9DiAB4A+V0e7Ir6k=",
+      "dev": true,
+      "requires": {
+        "handlebars": "^4.1.0"
+      }
+    },
+    "jest": {
+      "version": "24.5.0",
+      "resolved": "http://registry.npm.taobao.org/jest/download/jest-24.5.0.tgz",
+      "integrity": "sha1-OPEa4sK6ovhsK8TYqR0rUWEs0Zo=",
+      "dev": true,
+      "requires": {
+        "import-local": "^2.0.0",
+        "jest-cli": "^24.5.0"
+      },
+      "dependencies": {
+        "ci-info": {
+          "version": "2.0.0",
+          "resolved": "http://registry.npm.taobao.org/ci-info/download/ci-info-2.0.0.tgz",
+          "integrity": "sha1-Z6npZL4xpR4V5QENWObxKDQAL0Y=",
+          "dev": true
+        },
+        "is-ci": {
+          "version": "2.0.0",
+          "resolved": "http://registry.npm.taobao.org/is-ci/download/is-ci-2.0.0.tgz",
+          "integrity": "sha1-a8YzQYGBDgS1wis9WJ/cpVAmQEw=",
+          "dev": true,
+          "requires": {
+            "ci-info": "^2.0.0"
+          }
+        },
+        "jest-cli": {
+          "version": "24.5.0",
+          "resolved": "http://registry.npm.taobao.org/jest-cli/download/jest-cli-24.5.0.tgz",
+          "integrity": "sha1-WYE500RtGUL7fck5RLm6dm11bUs=",
+          "dev": true,
+          "requires": {
+            "@jest/core": "^24.5.0",
+            "@jest/test-result": "^24.5.0",
+            "@jest/types": "^24.5.0",
+            "chalk": "^2.0.1",
+            "exit": "^0.1.2",
+            "import-local": "^2.0.0",
+            "is-ci": "^2.0.0",
+            "jest-config": "^24.5.0",
+            "jest-util": "^24.5.0",
+            "jest-validate": "^24.5.0",
+            "prompts": "^2.0.1",
+            "realpath-native": "^1.1.0",
+            "yargs": "^12.0.2"
+          }
+        }
+      }
+    },
+    "jest-changed-files": {
+      "version": "24.5.0",
+      "resolved": "http://registry.npm.taobao.org/jest-changed-files/download/jest-changed-files-24.5.0.tgz",
+      "integrity": "sha1-QHUmnuEV2HGU/Vgi5kKvIhM89wU=",
+      "dev": true,
+      "requires": {
+        "@jest/types": "^24.5.0",
+        "execa": "^1.0.0",
+        "throat": "^4.0.0"
+      }
+    },
+    "jest-config": {
+      "version": "24.5.0",
+      "resolved": "http://registry.npm.taobao.org/jest-config/download/jest-config-24.5.0.tgz",
+      "integrity": "sha1-QE0bxruBrta9GJDQfi3Kn7ui4SE=",
+      "dev": true,
+      "requires": {
+        "@babel/core": "^7.1.0",
+        "@jest/types": "^24.5.0",
+        "babel-jest": "^24.5.0",
+        "chalk": "^2.0.1",
+        "glob": "^7.1.1",
+        "jest-environment-jsdom": "^24.5.0",
+        "jest-environment-node": "^24.5.0",
+        "jest-get-type": "^24.3.0",
+        "jest-jasmine2": "^24.5.0",
+        "jest-regex-util": "^24.3.0",
+        "jest-resolve": "^24.5.0",
+        "jest-util": "^24.5.0",
+        "jest-validate": "^24.5.0",
+        "micromatch": "^3.1.10",
+        "pretty-format": "^24.5.0",
+        "realpath-native": "^1.1.0"
+      }
+    },
+    "jest-diff": {
+      "version": "24.5.0",
+      "resolved": "http://registry.npm.taobao.org/jest-diff/download/jest-diff-24.5.0.tgz",
+      "integrity": "sha1-othieWS7BqkYk8D7yyirIowldlI=",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.0.1",
+        "diff-sequences": "^24.3.0",
+        "jest-get-type": "^24.3.0",
+        "pretty-format": "^24.5.0"
+      }
+    },
+    "jest-docblock": {
+      "version": "24.3.0",
+      "resolved": "http://registry.npm.taobao.org/jest-docblock/download/jest-docblock-24.3.0.tgz",
+      "integrity": "sha1-ucMtrHD3LkRkUg0rpK7AKrFNtd0=",
+      "dev": true,
+      "requires": {
+        "detect-newline": "^2.1.0"
+      }
+    },
+    "jest-each": {
+      "version": "24.5.0",
+      "resolved": "http://registry.npm.taobao.org/jest-each/download/jest-each-24.5.0.tgz",
+      "integrity": "sha1-2hTQF6G30PAftFjTODFMr+f3Ixg=",
+      "dev": true,
+      "requires": {
+        "@jest/types": "^24.5.0",
+        "chalk": "^2.0.1",
+        "jest-get-type": "^24.3.0",
+        "jest-util": "^24.5.0",
+        "pretty-format": "^24.5.0"
+      }
+    },
+    "jest-environment-jsdom": {
+      "version": "24.5.0",
+      "resolved": "http://registry.npm.taobao.org/jest-environment-jsdom/download/jest-environment-jsdom-24.5.0.tgz",
+      "integrity": "sha1-HDFDBj4TdBAPjCcjqLaq0jttt+s=",
+      "dev": true,
+      "requires": {
+        "@jest/environment": "^24.5.0",
+        "@jest/fake-timers": "^24.5.0",
+        "@jest/types": "^24.5.0",
+        "jest-mock": "^24.5.0",
+        "jest-util": "^24.5.0",
+        "jsdom": "^11.5.1"
+      }
+    },
+    "jest-environment-node": {
+      "version": "24.5.0",
+      "resolved": "http://registry.npm.taobao.org/jest-environment-node/download/jest-environment-node-24.5.0.tgz",
+      "integrity": "sha1-dj7r31KfdbYKpgDGz4ywmHPKpqs=",
+      "dev": true,
+      "requires": {
+        "@jest/environment": "^24.5.0",
+        "@jest/fake-timers": "^24.5.0",
+        "@jest/types": "^24.5.0",
+        "jest-mock": "^24.5.0",
+        "jest-util": "^24.5.0"
+      }
+    },
+    "jest-get-type": {
+      "version": "24.3.0",
+      "resolved": "http://registry.npm.taobao.org/jest-get-type/download/jest-get-type-24.3.0.tgz",
+      "integrity": "sha1-WCz9Gk+Rtc2tHUPSky+BbVQ8Zdo=",
+      "dev": true
+    },
+    "jest-haste-map": {
+      "version": "24.5.0",
+      "resolved": "http://registry.npm.taobao.org/jest-haste-map/download/jest-haste-map-24.5.0.tgz",
+      "integrity": "sha1-PxfQxUi5nAyW7SiT+cDM7LLrkGY=",
+      "dev": true,
+      "requires": {
+        "@jest/types": "^24.5.0",
+        "fb-watchman": "^2.0.0",
+        "graceful-fs": "^4.1.15",
+        "invariant": "^2.2.4",
+        "jest-serializer": "^24.4.0",
+        "jest-util": "^24.5.0",
+        "jest-worker": "^24.4.0",
+        "micromatch": "^3.1.10",
+        "sane": "^4.0.3"
+      }
+    },
+    "jest-jasmine2": {
+      "version": "24.5.0",
+      "resolved": "http://registry.npm.taobao.org/jest-jasmine2/download/jest-jasmine2-24.5.0.tgz",
+      "integrity": "sha1-5q9Nf3PcUn0AfMpaWxd8C8wp0RE=",
+      "dev": true,
+      "requires": {
+        "@babel/traverse": "^7.1.0",
+        "@jest/environment": "^24.5.0",
+        "@jest/test-result": "^24.5.0",
+        "@jest/types": "^24.5.0",
+        "chalk": "^2.0.1",
+        "co": "^4.6.0",
+        "expect": "^24.5.0",
+        "is-generator-fn": "^2.0.0",
+        "jest-each": "^24.5.0",
+        "jest-matcher-utils": "^24.5.0",
+        "jest-message-util": "^24.5.0",
+        "jest-runtime": "^24.5.0",
+        "jest-snapshot": "^24.5.0",
+        "jest-util": "^24.5.0",
+        "pretty-format": "^24.5.0",
+        "throat": "^4.0.0"
+      }
+    },
+    "jest-leak-detector": {
+      "version": "24.5.0",
+      "resolved": "http://registry.npm.taobao.org/jest-leak-detector/download/jest-leak-detector-24.5.0.tgz",
+      "integrity": "sha1-Ia4rOw2iUsEXHNSU91aW1l+2+ok=",
+      "dev": true,
+      "requires": {
+        "pretty-format": "^24.5.0"
+      }
+    },
+    "jest-matcher-utils": {
+      "version": "24.5.0",
+      "resolved": "http://registry.npm.taobao.org/jest-matcher-utils/download/jest-matcher-utils-24.5.0.tgz",
+      "integrity": "sha1-WZVUnc8J+pRAbolSbod7CU2th3A=",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.0.1",
+        "jest-diff": "^24.5.0",
+        "jest-get-type": "^24.3.0",
+        "pretty-format": "^24.5.0"
+      }
+    },
+    "jest-message-util": {
+      "version": "24.5.0",
+      "resolved": "http://registry.npm.taobao.org/jest-message-util/download/jest-message-util-24.5.0.tgz",
+      "integrity": "sha1-GBQgplp+8ui1wvjhSILEU8bUHQc=",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "@jest/test-result": "^24.5.0",
+        "@jest/types": "^24.5.0",
+        "@types/stack-utils": "^1.0.1",
+        "chalk": "^2.0.1",
+        "micromatch": "^3.1.10",
+        "slash": "^2.0.0",
+        "stack-utils": "^1.0.1"
+      }
+    },
+    "jest-mock": {
+      "version": "24.5.0",
+      "resolved": "http://registry.npm.taobao.org/jest-mock/download/jest-mock-24.5.0.tgz",
+      "integrity": "sha1-l2kSyZqT8qHGdJepQUqk2dpMe3Y=",
+      "dev": true,
+      "requires": {
+        "@jest/types": "^24.5.0"
+      }
+    },
+    "jest-pnp-resolver": {
+      "version": "1.2.1",
+      "resolved": "http://registry.npm.taobao.org/jest-pnp-resolver/download/jest-pnp-resolver-1.2.1.tgz",
+      "integrity": "sha1-7NrmBMB3p/vHDe+21RfDwciYkjo=",
+      "dev": true
+    },
+    "jest-regex-util": {
+      "version": "24.3.0",
+      "resolved": "http://registry.npm.taobao.org/jest-regex-util/download/jest-regex-util-24.3.0.tgz",
+      "integrity": "sha1-1aZfYL4a4+MQ1SFKAwdYGZUiezY=",
+      "dev": true
+    },
+    "jest-resolve": {
+      "version": "24.5.0",
+      "resolved": "http://registry.npm.taobao.org/jest-resolve/download/jest-resolve-24.5.0.tgz",
+      "integrity": "sha1-jBa6CPYKFhbDsc16+yRXT1CiTQQ=",
+      "dev": true,
+      "requires": {
+        "@jest/types": "^24.5.0",
+        "browser-resolve": "^1.11.3",
+        "chalk": "^2.0.1",
+        "jest-pnp-resolver": "^1.2.1",
+        "realpath-native": "^1.1.0"
+      }
+    },
+    "jest-resolve-dependencies": {
+      "version": "24.5.0",
+      "resolved": "http://registry.npm.taobao.org/jest-resolve-dependencies/download/jest-resolve-dependencies-24.5.0.tgz",
+      "integrity": "sha1-Gg2unN1BNJykqEFIs+eNoroz/Us=",
+      "dev": true,
+      "requires": {
+        "@jest/types": "^24.5.0",
+        "jest-regex-util": "^24.3.0",
+        "jest-snapshot": "^24.5.0"
+      }
+    },
+    "jest-runner": {
+      "version": "24.5.0",
+      "resolved": "http://registry.npm.taobao.org/jest-runner/download/jest-runner-24.5.0.tgz",
+      "integrity": "sha1-m+Juzk/Uqz37UouIdSMUS3xf/Kg=",
+      "dev": true,
+      "requires": {
+        "@jest/console": "^24.3.0",
+        "@jest/environment": "^24.5.0",
+        "@jest/test-result": "^24.5.0",
+        "@jest/types": "^24.5.0",
+        "chalk": "^2.4.2",
+        "exit": "^0.1.2",
+        "graceful-fs": "^4.1.15",
+        "jest-config": "^24.5.0",
+        "jest-docblock": "^24.3.0",
+        "jest-haste-map": "^24.5.0",
+        "jest-jasmine2": "^24.5.0",
+        "jest-leak-detector": "^24.5.0",
+        "jest-message-util": "^24.5.0",
+        "jest-resolve": "^24.5.0",
+        "jest-runtime": "^24.5.0",
+        "jest-util": "^24.5.0",
+        "jest-worker": "^24.4.0",
+        "source-map-support": "^0.5.6",
+        "throat": "^4.0.0"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "http://registry.npm.taobao.org/chalk/download/chalk-2.4.2.tgz",
+          "integrity": "sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        }
+      }
+    },
+    "jest-runtime": {
+      "version": "24.5.0",
+      "resolved": "http://registry.npm.taobao.org/jest-runtime/download/jest-runtime-24.5.0.tgz",
+      "integrity": "sha1-Onbgv+9Ns4ltURbp5Ri+R7p3GqI=",
+      "dev": true,
+      "requires": {
+        "@jest/console": "^24.3.0",
+        "@jest/environment": "^24.5.0",
+        "@jest/source-map": "^24.3.0",
+        "@jest/transform": "^24.5.0",
+        "@jest/types": "^24.5.0",
+        "@types/yargs": "^12.0.2",
+        "chalk": "^2.0.1",
+        "exit": "^0.1.2",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.1.15",
+        "jest-config": "^24.5.0",
+        "jest-haste-map": "^24.5.0",
+        "jest-message-util": "^24.5.0",
+        "jest-mock": "^24.5.0",
+        "jest-regex-util": "^24.3.0",
+        "jest-resolve": "^24.5.0",
+        "jest-snapshot": "^24.5.0",
+        "jest-util": "^24.5.0",
+        "jest-validate": "^24.5.0",
+        "realpath-native": "^1.1.0",
+        "slash": "^2.0.0",
+        "strip-bom": "^3.0.0",
+        "yargs": "^12.0.2"
+      }
+    },
+    "jest-serializer": {
+      "version": "24.4.0",
+      "resolved": "http://registry.npm.taobao.org/jest-serializer/download/jest-serializer-24.4.0.tgz",
+      "integrity": "sha1-9wxZGMjqkjXMsSdtIy5FkIBYjbM=",
+      "dev": true
+    },
+    "jest-snapshot": {
+      "version": "24.5.0",
+      "resolved": "http://registry.npm.taobao.org/jest-snapshot/download/jest-snapshot-24.5.0.tgz",
+      "integrity": "sha1-5dIkRop1n9GeNvASF6rJEvUA93k=",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.0.0",
+        "@jest/types": "^24.5.0",
+        "chalk": "^2.0.1",
+        "expect": "^24.5.0",
+        "jest-diff": "^24.5.0",
+        "jest-matcher-utils": "^24.5.0",
+        "jest-message-util": "^24.5.0",
+        "jest-resolve": "^24.5.0",
+        "mkdirp": "^0.5.1",
+        "natural-compare": "^1.4.0",
+        "pretty-format": "^24.5.0",
+        "semver": "^5.5.0"
+      }
+    },
+    "jest-util": {
+      "version": "24.5.0",
+      "resolved": "http://registry.npm.taobao.org/jest-util/download/jest-util-24.5.0.tgz",
+      "integrity": "sha1-nZywbZ3MzI58x235GxY1Al17qoQ=",
+      "dev": true,
+      "requires": {
+        "@jest/console": "^24.3.0",
+        "@jest/fake-timers": "^24.5.0",
+        "@jest/source-map": "^24.3.0",
+        "@jest/test-result": "^24.5.0",
+        "@jest/types": "^24.5.0",
+        "@types/node": "*",
+        "callsites": "^3.0.0",
+        "chalk": "^2.0.1",
+        "graceful-fs": "^4.1.15",
+        "is-ci": "^2.0.0",
+        "mkdirp": "^0.5.1",
+        "slash": "^2.0.0",
+        "source-map": "^0.6.0"
+      },
+      "dependencies": {
+        "callsites": {
+          "version": "3.0.0",
+          "resolved": "http://registry.npm.taobao.org/callsites/download/callsites-3.0.0.tgz",
+          "integrity": "sha1-+361abcq16RYEvk/2UMKPkELPdM=",
+          "dev": true
+        },
+        "ci-info": {
+          "version": "2.0.0",
+          "resolved": "http://registry.npm.taobao.org/ci-info/download/ci-info-2.0.0.tgz",
+          "integrity": "sha1-Z6npZL4xpR4V5QENWObxKDQAL0Y=",
+          "dev": true
+        },
+        "is-ci": {
+          "version": "2.0.0",
+          "resolved": "http://registry.npm.taobao.org/is-ci/download/is-ci-2.0.0.tgz",
+          "integrity": "sha1-a8YzQYGBDgS1wis9WJ/cpVAmQEw=",
+          "dev": true,
+          "requires": {
+            "ci-info": "^2.0.0"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "http://registry.npm.taobao.org/source-map/download/source-map-0.6.1.tgz",
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+          "dev": true
+        }
+      }
+    },
+    "jest-validate": {
+      "version": "24.5.0",
+      "resolved": "http://registry.npm.taobao.org/jest-validate/download/jest-validate-24.5.0.tgz",
+      "integrity": "sha1-Yv2T2BIUwHC7LXpV8ymnnYBXx94=",
+      "dev": true,
+      "requires": {
+        "@jest/types": "^24.5.0",
+        "camelcase": "^5.0.0",
+        "chalk": "^2.0.1",
+        "jest-get-type": "^24.3.0",
+        "leven": "^2.1.0",
+        "pretty-format": "^24.5.0"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "5.2.0",
+          "resolved": "http://registry.npm.taobao.org/camelcase/download/camelcase-5.2.0.tgz",
+          "integrity": "sha1-51IqvaXtlMwEieG4RmYQ6IQEz0U=",
+          "dev": true
+        }
+      }
+    },
+    "jest-watcher": {
+      "version": "24.5.0",
+      "resolved": "http://registry.npm.taobao.org/jest-watcher/download/jest-watcher-24.5.0.tgz",
+      "integrity": "sha1-2nvZy1ln4nSIm0IHjI9QGuHEd2E=",
+      "dev": true,
+      "requires": {
+        "@jest/test-result": "^24.5.0",
+        "@jest/types": "^24.5.0",
+        "@types/node": "*",
+        "@types/yargs": "^12.0.9",
+        "ansi-escapes": "^3.0.0",
+        "chalk": "^2.0.1",
+        "jest-util": "^24.5.0",
+        "string-length": "^2.0.0"
+      }
+    },
+    "jest-worker": {
+      "version": "24.4.0",
+      "resolved": "http://registry.npm.taobao.org/jest-worker/download/jest-worker-24.4.0.tgz",
+      "integrity": "sha1-+8RSsBILtcKnDNyI+hMrSO6xHdA=",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "merge-stream": "^1.0.1",
+        "supports-color": "^6.1.0"
+      },
+      "dependencies": {
+        "supports-color": {
+          "version": "6.1.0",
+          "resolved": "http://registry.npm.taobao.org/supports-color/download/supports-color-6.1.0.tgz",
+          "integrity": "sha1-B2Srxpxj1ayELdSGfo0CXogN+PM=",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
     "js-levenshtein": {
       "version": "1.1.4",
       "resolved": "http://registry.npm.taobao.org/js-levenshtein/download/js-levenshtein-1.1.4.tgz",
@@ -6457,6 +8117,60 @@
         "esprima": "^4.0.0"
       }
     },
+    "jsbn": {
+      "version": "0.1.1",
+      "resolved": "http://registry.npm.taobao.org/jsbn/download/jsbn-0.1.1.tgz",
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+      "dev": true
+    },
+    "jsdom": {
+      "version": "11.12.0",
+      "resolved": "http://registry.npm.taobao.org/jsdom/download/jsdom-11.12.0.tgz",
+      "integrity": "sha1-GoDUDd03ih3lllbp5txaO6hle8g=",
+      "dev": true,
+      "requires": {
+        "abab": "^2.0.0",
+        "acorn": "^5.5.3",
+        "acorn-globals": "^4.1.0",
+        "array-equal": "^1.0.0",
+        "cssom": ">= 0.3.2 < 0.4.0",
+        "cssstyle": "^1.0.0",
+        "data-urls": "^1.0.0",
+        "domexception": "^1.0.1",
+        "escodegen": "^1.9.1",
+        "html-encoding-sniffer": "^1.0.2",
+        "left-pad": "^1.3.0",
+        "nwsapi": "^2.0.7",
+        "parse5": "4.0.0",
+        "pn": "^1.1.0",
+        "request": "^2.87.0",
+        "request-promise-native": "^1.0.5",
+        "sax": "^1.2.4",
+        "symbol-tree": "^3.2.2",
+        "tough-cookie": "^2.3.4",
+        "w3c-hr-time": "^1.0.1",
+        "webidl-conversions": "^4.0.2",
+        "whatwg-encoding": "^1.0.3",
+        "whatwg-mimetype": "^2.1.0",
+        "whatwg-url": "^6.4.1",
+        "ws": "^5.2.0",
+        "xml-name-validator": "^3.0.0"
+      },
+      "dependencies": {
+        "parse5": {
+          "version": "4.0.0",
+          "resolved": "http://registry.npm.taobao.org/parse5/download/parse5-4.0.0.tgz",
+          "integrity": "sha1-bXhlbj2o14tOwLkG98CO8d/j9gg=",
+          "dev": true
+        },
+        "sax": {
+          "version": "1.2.4",
+          "resolved": "http://registry.npm.taobao.org/sax/download/sax-1.2.4.tgz",
+          "integrity": "sha1-KBYjTiN4vdxOU1T6tcqold9xANk=",
+          "dev": true
+        }
+      }
+    },
     "jsesc": {
       "version": "0.5.0",
       "resolved": "http://registry.npm.taobao.org/jsesc/download/jsesc-0.5.0.tgz",
@@ -6475,6 +8189,12 @@
       "integrity": "sha1-u4Z8+zRQ5pEHwTHRxRS6s9yLyqk=",
       "dev": true
     },
+    "json-schema": {
+      "version": "0.2.3",
+      "resolved": "http://registry.npm.taobao.org/json-schema/download/json-schema-0.2.3.tgz",
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+      "dev": true
+    },
     "json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "http://registry.npm.taobao.org/json-schema-traverse/download/json-schema-traverse-0.4.1.tgz",
@@ -6485,6 +8205,12 @@
       "version": "1.0.1",
       "resolved": "http://registry.npm.taobao.org/json-stable-stringify-without-jsonify/download/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+      "dev": true
+    },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "http://registry.npm.taobao.org/json-stringify-safe/download/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
       "dev": true
     },
     "json3": {
@@ -6504,6 +8230,18 @@
       "resolved": "http://registry.npm.taobao.org/jsonparse/download/jsonparse-1.3.1.tgz",
       "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
       "dev": true
+    },
+    "jsprim": {
+      "version": "1.4.1",
+      "resolved": "http://registry.npm.taobao.org/jsprim/download/jsprim-1.4.1.tgz",
+      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.2.3",
+        "verror": "1.10.0"
+      }
     },
     "jsx-ast-utils": {
       "version": "2.0.1",
@@ -6526,6 +8264,12 @@
       "integrity": "sha1-ARRrNqYhjmTljzqNZt5df8b20FE=",
       "dev": true
     },
+    "kleur": {
+      "version": "3.0.2",
+      "resolved": "http://registry.npm.taobao.org/kleur/download/kleur-3.0.2.tgz",
+      "integrity": "sha1-g8fshYpBCYthPVmYp7ZTlitQT2g=",
+      "dev": true
+    },
     "lcid": {
       "version": "2.0.0",
       "resolved": "http://registry.npm.taobao.org/lcid/download/lcid-2.0.0.tgz",
@@ -6534,6 +8278,18 @@
       "requires": {
         "invert-kv": "^2.0.0"
       }
+    },
+    "left-pad": {
+      "version": "1.3.0",
+      "resolved": "http://registry.npm.taobao.org/left-pad/download/left-pad-1.3.0.tgz",
+      "integrity": "sha1-W4o6d2Xf4AEmHd6RVYnngvjJTR4=",
+      "dev": true
+    },
+    "leven": {
+      "version": "2.1.0",
+      "resolved": "http://registry.npm.taobao.org/leven/download/leven-2.1.0.tgz",
+      "integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA=",
+      "dev": true
     },
     "levn": {
       "version": "0.3.0",
@@ -6810,10 +8566,28 @@
       "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
       "dev": true
     },
+    "lodash.escape": {
+      "version": "4.0.1",
+      "resolved": "http://registry.npm.taobao.org/lodash.escape/download/lodash.escape-4.0.1.tgz",
+      "integrity": "sha1-yQRGkMIeBClL6qUXcS/e0fqI3pg=",
+      "dev": true
+    },
+    "lodash.flattendeep": {
+      "version": "4.4.0",
+      "resolved": "http://registry.npm.taobao.org/lodash.flattendeep/download/lodash.flattendeep-4.4.0.tgz",
+      "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
+      "dev": true
+    },
     "lodash.get": {
       "version": "4.4.2",
       "resolved": "http://registry.npm.taobao.org/lodash.get/download/lodash.get-4.4.2.tgz",
       "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
+      "dev": true
+    },
+    "lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "http://registry.npm.taobao.org/lodash.isequal/download/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA=",
       "dev": true
     },
     "lodash.kebabcase": {
@@ -6850,6 +8624,12 @@
       "version": "4.1.1",
       "resolved": "http://registry.npm.taobao.org/lodash.snakecase/download/lodash.snakecase-4.1.1.tgz",
       "integrity": "sha1-OdcUo1NXFHg3rv1ktdy7Fr7Nj40=",
+      "dev": true
+    },
+    "lodash.sortby": {
+      "version": "4.7.0",
+      "resolved": "http://registry.npm.taobao.org/lodash.sortby/download/lodash.sortby-4.7.0.tgz",
+      "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
       "dev": true
     },
     "lodash.startcase": {
@@ -6993,6 +8773,15 @@
         "pify": "^3.0.0"
       }
     },
+    "makeerror": {
+      "version": "1.0.11",
+      "resolved": "http://registry.npm.taobao.org/makeerror/download/makeerror-1.0.11.tgz",
+      "integrity": "sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=",
+      "dev": true,
+      "requires": {
+        "tmpl": "1.0.x"
+      }
+    },
     "map-age-cleaner": {
       "version": "0.1.3",
       "resolved": "http://registry.npm.taobao.org/map-age-cleaner/download/map-age-cleaner-0.1.3.tgz",
@@ -7123,6 +8912,15 @@
       "resolved": "http://registry.npm.taobao.org/merge-descriptors/download/merge-descriptors-1.0.1.tgz",
       "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
       "dev": true
+    },
+    "merge-stream": {
+      "version": "1.0.1",
+      "resolved": "http://registry.npm.taobao.org/merge-stream/download/merge-stream-1.0.1.tgz",
+      "integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
+      "dev": true,
+      "requires": {
+        "readable-stream": "^2.0.1"
+      }
     },
     "methods": {
       "version": "1.1.2",
@@ -7323,6 +9121,12 @@
         }
       }
     },
+    "moo": {
+      "version": "0.4.3",
+      "resolved": "http://registry.npm.taobao.org/moo/download/moo-0.4.3.tgz",
+      "integrity": "sha1-P4R6JvMc9iWpVqh/KxD7wBO/0Q4=",
+      "dev": true
+    },
     "move-concurrently": {
       "version": "1.0.1",
       "resolved": "http://registry.npm.taobao.org/move-concurrently/download/move-concurrently-1.0.1.tgz",
@@ -7397,6 +9201,27 @@
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
     },
+    "nearley": {
+      "version": "2.16.0",
+      "resolved": "http://registry.npm.taobao.org/nearley/download/nearley-2.16.0.tgz",
+      "integrity": "sha1-d8KX0EGUHSaCkOyEtznQ7il+g6c=",
+      "dev": true,
+      "requires": {
+        "commander": "^2.19.0",
+        "moo": "^0.4.3",
+        "railroad-diagrams": "^1.0.0",
+        "randexp": "0.4.6",
+        "semver": "^5.4.1"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.19.0",
+          "resolved": "http://registry.npm.taobao.org/commander/download/commander-2.19.0.tgz",
+          "integrity": "sha1-9hmKqE5bg8RgVLlN3tv+1e6f8So=",
+          "dev": true
+        }
+      }
+    },
     "negotiator": {
       "version": "0.6.1",
       "resolved": "http://registry.npm.taobao.org/negotiator/download/negotiator-0.6.1.tgz",
@@ -7436,6 +9261,12 @@
       "integrity": "sha1-bBUsNFzhHFL0ZcKr2VfoY5zWdN8=",
       "dev": true
     },
+    "node-int64": {
+      "version": "0.4.0",
+      "resolved": "http://registry.npm.taobao.org/node-int64/download/node-int64-0.4.0.tgz",
+      "integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs=",
+      "dev": true
+    },
     "node-libs-browser": {
       "version": "2.1.0",
       "resolved": "http://registry.npm.taobao.org/node-libs-browser/download/node-libs-browser-2.1.0.tgz",
@@ -7473,6 +9304,25 @@
           "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
           "dev": true
         }
+      }
+    },
+    "node-modules-regexp": {
+      "version": "1.0.0",
+      "resolved": "http://registry.npm.taobao.org/node-modules-regexp/download/node-modules-regexp-1.0.0.tgz",
+      "integrity": "sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA=",
+      "dev": true
+    },
+    "node-notifier": {
+      "version": "5.4.0",
+      "resolved": "http://registry.npm.taobao.org/node-notifier/download/node-notifier-5.4.0.tgz",
+      "integrity": "sha1-e0Vf3On33gxjU4KXNU89tGhCbmo=",
+      "dev": true,
+      "requires": {
+        "growly": "^1.3.0",
+        "is-wsl": "^1.1.0",
+        "semver": "^5.5.0",
+        "shellwords": "^0.1.1",
+        "which": "^1.3.0"
       }
     },
     "node-releases": {
@@ -7555,6 +9405,18 @@
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
       "dev": true
     },
+    "nwsapi": {
+      "version": "2.1.1",
+      "resolved": "http://registry.npm.taobao.org/nwsapi/download/nwsapi-2.1.1.tgz",
+      "integrity": "sha1-CNbXXmn9eRveoxUH/6/oyEO2fpw=",
+      "dev": true
+    },
+    "oauth-sign": {
+      "version": "0.9.0",
+      "resolved": "http://registry.npm.taobao.org/oauth-sign/download/oauth-sign-0.9.0.tgz",
+      "integrity": "sha1-R6ewFrqmi1+g7PPe4IqFxnmsZFU=",
+      "dev": true
+    },
     "object-assign": {
       "version": "4.1.1",
       "resolved": "http://registry.npm.taobao.org/object-assign/download/object-assign-4.1.1.tgz",
@@ -7591,6 +9453,18 @@
           }
         }
       }
+    },
+    "object-inspect": {
+      "version": "1.6.0",
+      "resolved": "http://registry.npm.taobao.org/object-inspect/download/object-inspect-1.6.0.tgz",
+      "integrity": "sha1-xwtsv3LydKq0w0wMgvUWe/gs8Vs=",
+      "dev": true
+    },
+    "object-is": {
+      "version": "1.0.1",
+      "resolved": "http://registry.npm.taobao.org/object-is/download/object-is-1.0.1.tgz",
+      "integrity": "sha1-CqYOyZiaCz7Xlc9NBvYs8a1lObY=",
+      "dev": true
     },
     "object-keys": {
       "version": "1.0.12",
@@ -7662,6 +9536,18 @@
         "isobject": "^3.0.1"
       }
     },
+    "object.values": {
+      "version": "1.1.0",
+      "resolved": "http://registry.npm.taobao.org/object.values/download/object.values-1.1.0.tgz",
+      "integrity": "sha1-v2gQ712j5TJXkOqqK+IT6oRiTak=",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.12.0",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3"
+      }
+    },
     "obuf": {
       "version": "1.1.2",
       "resolved": "http://registry.npm.taobao.org/obuf/download/obuf-1.1.2.tgz",
@@ -7708,6 +9594,30 @@
       "dev": true,
       "requires": {
         "is-wsl": "^1.1.0"
+      }
+    },
+    "optimist": {
+      "version": "0.6.1",
+      "resolved": "http://registry.npm.taobao.org/optimist/download/optimist-0.6.1.tgz",
+      "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+      "dev": true,
+      "requires": {
+        "minimist": "~0.0.1",
+        "wordwrap": "~0.0.2"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "0.0.10",
+          "resolved": "http://registry.npm.taobao.org/minimist/download/minimist-0.0.10.tgz",
+          "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
+          "dev": true
+        },
+        "wordwrap": {
+          "version": "0.0.3",
+          "resolved": "http://registry.npm.taobao.org/wordwrap/download/wordwrap-0.0.3.tgz",
+          "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+          "dev": true
+        }
       }
     },
     "optionator": {
@@ -7796,6 +9706,15 @@
       "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=",
       "dev": true
     },
+    "p-each-series": {
+      "version": "1.0.0",
+      "resolved": "http://registry.npm.taobao.org/p-each-series/download/p-each-series-1.0.0.tgz",
+      "integrity": "sha1-kw89Et0fUOdDRFeiLNbwSsatf3E=",
+      "dev": true,
+      "requires": {
+        "p-reduce": "^1.0.0"
+      }
+    },
     "p-finally": {
       "version": "1.0.0",
       "resolved": "http://registry.npm.taobao.org/p-finally/download/p-finally-1.0.0.tgz",
@@ -7830,6 +9749,12 @@
       "version": "1.2.0",
       "resolved": "http://registry.npm.taobao.org/p-map/download/p-map-1.2.0.tgz",
       "integrity": "sha1-5OlPMR6rvIYzoeeZCBZfyiYkG2s=",
+      "dev": true
+    },
+    "p-reduce": {
+      "version": "1.0.0",
+      "resolved": "http://registry.npm.taobao.org/p-reduce/download/p-reduce-1.0.0.tgz",
+      "integrity": "sha1-GMKw3ZNqRpClKfgjH1ig/bakffo=",
       "dev": true
     },
     "p-try": {
@@ -7918,6 +9843,15 @@
         "json-parse-better-errors": "^1.0.1"
       }
     },
+    "parse5": {
+      "version": "3.0.3",
+      "resolved": "http://registry.npm.taobao.org/parse5/download/parse5-3.0.3.tgz",
+      "integrity": "sha1-BC95L/3TaFFVHPTp4Gazh0q0W1w=",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "parseurl": {
       "version": "1.3.2",
       "resolved": "http://registry.npm.taobao.org/parseurl/download/parseurl-1.3.2.tgz",
@@ -8000,6 +9934,12 @@
         "sha.js": "^2.4.8"
       }
     },
+    "performance-now": {
+      "version": "2.1.0",
+      "resolved": "http://registry.npm.taobao.org/performance-now/download/performance-now-2.1.0.tgz",
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+      "dev": true
+    },
     "pify": {
       "version": "3.0.0",
       "resolved": "http://registry.npm.taobao.org/pify/download/pify-3.0.0.tgz",
@@ -8019,6 +9959,15 @@
       "dev": true,
       "requires": {
         "pinkie": "^2.0.0"
+      }
+    },
+    "pirates": {
+      "version": "4.0.1",
+      "resolved": "http://registry.npm.taobao.org/pirates/download/pirates-4.0.1.tgz",
+      "integrity": "sha1-ZDqSyviUVm+RsrmG0sZpUKji+4c=",
+      "dev": true,
+      "requires": {
+        "node-modules-regexp": "^1.0.0"
       }
     },
     "pkg-dir": {
@@ -8083,6 +10032,12 @@
       "requires": {
         "semver-compare": "^1.0.0"
       }
+    },
+    "pn": {
+      "version": "1.1.0",
+      "resolved": "http://registry.npm.taobao.org/pn/download/pn-1.1.0.tgz",
+      "integrity": "sha1-4vTO8OIZ9GPBeas3Rj5OHs3Muvs=",
+      "dev": true
     },
     "portfinder": {
       "version": "1.0.20",
@@ -8207,6 +10162,26 @@
         "utila": "~0.4"
       }
     },
+    "pretty-format": {
+      "version": "24.5.0",
+      "resolved": "http://registry.npm.taobao.org/pretty-format/download/pretty-format-24.5.0.tgz",
+      "integrity": "sha1-zGmgKBpizXJCYz/BNdaTDNiJgi0=",
+      "dev": true,
+      "requires": {
+        "@jest/types": "^24.5.0",
+        "ansi-regex": "^4.0.0",
+        "ansi-styles": "^3.2.0",
+        "react-is": "^16.8.4"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "http://registry.npm.taobao.org/ansi-regex/download/ansi-regex-4.1.0.tgz",
+          "integrity": "sha1-i5+PCM8ay4Q3Vqg5yox+MWjFGZc=",
+          "dev": true
+        }
+      }
+    },
     "private": {
       "version": "0.1.8",
       "resolved": "http://registry.npm.taobao.org/private/download/private-0.1.8.tgz",
@@ -8236,6 +10211,16 @@
       "resolved": "http://registry.npm.taobao.org/promise-inflight/download/promise-inflight-1.0.1.tgz",
       "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM=",
       "dev": true
+    },
+    "prompts": {
+      "version": "2.0.3",
+      "resolved": "http://registry.npm.taobao.org/prompts/download/prompts-2.0.3.tgz",
+      "integrity": "sha1-xcyzJAELLo90dSqtzutXE0wdJSI=",
+      "dev": true,
+      "requires": {
+        "kleur": "^3.0.2",
+        "sisteransi": "^1.0.0"
+      }
     },
     "prop-types": {
       "version": "15.6.2",
@@ -8273,6 +10258,12 @@
       "version": "1.0.2",
       "resolved": "http://registry.npm.taobao.org/pseudomap/download/pseudomap-1.0.2.tgz",
       "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+      "dev": true
+    },
+    "psl": {
+      "version": "1.1.31",
+      "resolved": "http://registry.npm.taobao.org/psl/download/psl-1.1.31.tgz",
+      "integrity": "sha1-6aqG0BAbWxBcvpOsa3hM1UcnYYQ=",
       "dev": true
     },
     "public-encrypt": {
@@ -8364,11 +10355,36 @@
       "integrity": "sha1-Q2CxfGETatOAeDl/8RQW4Ybc+7g=",
       "dev": true
     },
+    "raf": {
+      "version": "3.4.1",
+      "resolved": "http://registry.npm.taobao.org/raf/download/raf-3.4.1.tgz",
+      "integrity": "sha1-B0LpmkplUvRF1z4+4DKK8P8e3jk=",
+      "dev": true,
+      "requires": {
+        "performance-now": "^2.1.0"
+      }
+    },
+    "railroad-diagrams": {
+      "version": "1.0.0",
+      "resolved": "http://registry.npm.taobao.org/railroad-diagrams/download/railroad-diagrams-1.0.0.tgz",
+      "integrity": "sha1-635iZ1SN3t+4mcG5Dlc3RVnN234=",
+      "dev": true
+    },
     "ramda": {
       "version": "0.26.1",
       "resolved": "http://registry.npm.taobao.org/ramda/download/ramda-0.26.1.tgz",
       "integrity": "sha1-jUE1HrgRHFU1Nhf8O7/62OTTXQY=",
       "dev": true
+    },
+    "randexp": {
+      "version": "0.4.6",
+      "resolved": "http://registry.npm.taobao.org/randexp/download/randexp-0.4.6.tgz",
+      "integrity": "sha1-6YatXl4x2uE93W97MBmqfIf2DKM=",
+      "dev": true,
+      "requires": {
+        "discontinuous-range": "1.0.0",
+        "ret": "~0.1.10"
+      }
     },
     "randombytes": {
       "version": "2.0.6",
@@ -8437,6 +10453,12 @@
         "scheduler": "^0.11.2"
       }
     },
+    "react-is": {
+      "version": "16.8.4",
+      "resolved": "http://registry.npm.taobao.org/react-is/download/react-is-16.8.4.tgz",
+      "integrity": "sha1-kPM2pow6KaCWo9ZIq4DofsYUgqI=",
+      "dev": true
+    },
     "react-markdown": {
       "version": "4.0.4",
       "resolved": "http://registry.npm.taobao.org/react-markdown/download/react-markdown-4.0.4.tgz",
@@ -8498,6 +10520,30 @@
         "warning": "^4.0.1"
       }
     },
+    "react-test-renderer": {
+      "version": "16.8.4",
+      "resolved": "http://registry.npm.taobao.org/react-test-renderer/download/react-test-renderer-16.8.4.tgz",
+      "integrity": "sha1-q+5MLDv5Z6iJKns393NwxVcNUyk=",
+      "dev": true,
+      "requires": {
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.2",
+        "react-is": "^16.8.4",
+        "scheduler": "^0.13.4"
+      },
+      "dependencies": {
+        "scheduler": {
+          "version": "0.13.4",
+          "resolved": "http://registry.npm.taobao.org/scheduler/download/scheduler-0.13.4.tgz",
+          "integrity": "sha1-j+8F56NYDHbANk0t9eVQ5MkUApg=",
+          "dev": true,
+          "requires": {
+            "loose-envify": "^1.1.0",
+            "object-assign": "^4.1.1"
+          }
+        }
+      }
+    },
     "read-pkg": {
       "version": "3.0.0",
       "resolved": "http://registry.npm.taobao.org/read-pkg/download/read-pkg-3.0.0.tgz",
@@ -8543,6 +10589,15 @@
         "graceful-fs": "^4.1.11",
         "micromatch": "^3.1.10",
         "readable-stream": "^2.0.2"
+      }
+    },
+    "realpath-native": {
+      "version": "1.1.0",
+      "resolved": "http://registry.npm.taobao.org/realpath-native/download/realpath-native-1.1.0.tgz",
+      "integrity": "sha1-IAMpT+oj+wZy8kduviL89Jii1lw=",
+      "dev": true,
+      "requires": {
+        "util.promisify": "^1.0.0"
       }
     },
     "recast": {
@@ -8730,6 +10785,72 @@
       "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs=",
       "dev": true
     },
+    "request": {
+      "version": "2.88.0",
+      "resolved": "http://registry.npm.taobao.org/request/download/request-2.88.0.tgz",
+      "integrity": "sha1-nC/KT301tZLv5Xx/ClXoEFIST+8=",
+      "dev": true,
+      "requires": {
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.8.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.6",
+        "extend": "~3.0.2",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.2",
+        "har-validator": "~5.1.0",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.19",
+        "oauth-sign": "~0.9.0",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.2",
+        "safe-buffer": "^5.1.2",
+        "tough-cookie": "~2.4.3",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "1.4.1",
+          "resolved": "http://registry.npm.taobao.org/punycode/download/punycode-1.4.1.tgz",
+          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+          "dev": true
+        },
+        "tough-cookie": {
+          "version": "2.4.3",
+          "resolved": "http://registry.npm.taobao.org/tough-cookie/download/tough-cookie-2.4.3.tgz",
+          "integrity": "sha1-U/Nto/R3g7CSWvoG/587FlKA94E=",
+          "dev": true,
+          "requires": {
+            "psl": "^1.1.24",
+            "punycode": "^1.4.1"
+          }
+        }
+      }
+    },
+    "request-promise-core": {
+      "version": "1.1.2",
+      "resolved": "http://registry.npm.taobao.org/request-promise-core/download/request-promise-core-1.1.2.tgz",
+      "integrity": "sha1-M59qq6vK/bMceZ/xWHADNjAdM0Y=",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.11"
+      }
+    },
+    "request-promise-native": {
+      "version": "1.0.7",
+      "resolved": "http://registry.npm.taobao.org/request-promise-native/download/request-promise-native-1.0.7.tgz",
+      "integrity": "sha1-pJhopiS96lBp8SUdCoNuDYmqLFk=",
+      "dev": true,
+      "requires": {
+        "request-promise-core": "1.1.2",
+        "stealthy-require": "^1.1.1",
+        "tough-cookie": "^2.3.3"
+      }
+    },
     "require-directory": {
       "version": "2.1.1",
       "resolved": "http://registry.npm.taobao.org/require-directory/download/require-directory-2.1.1.tgz",
@@ -8883,6 +11004,22 @@
         "inherits": "^2.0.1"
       }
     },
+    "rst-selector-parser": {
+      "version": "2.2.3",
+      "resolved": "http://registry.npm.taobao.org/rst-selector-parser/download/rst-selector-parser-2.2.3.tgz",
+      "integrity": "sha1-gbIw6i/MYGbInjRy3nlChdmwPZE=",
+      "dev": true,
+      "requires": {
+        "lodash.flattendeep": "^4.4.0",
+        "nearley": "^2.7.10"
+      }
+    },
+    "rsvp": {
+      "version": "3.6.2",
+      "resolved": "http://registry.npm.taobao.org/rsvp/download/rsvp-3.6.2.tgz",
+      "integrity": "sha1-LpZJFZmpbN4bUV1WdKj3qRRSkmo=",
+      "dev": true
+    },
     "run-async": {
       "version": "2.3.0",
       "resolved": "http://registry.npm.taobao.org/run-async/download/run-async-2.3.0.tgz",
@@ -8936,6 +11073,23 @@
       "resolved": "http://registry.npm.taobao.org/safer-buffer/download/safer-buffer-2.1.2.tgz",
       "integrity": "sha1-RPoWGwGHuVSd2Eu5GAL5vYOFzWo=",
       "dev": true
+    },
+    "sane": {
+      "version": "4.0.3",
+      "resolved": "http://registry.npm.taobao.org/sane/download/sane-4.0.3.tgz",
+      "integrity": "sha1-6HjD8Z4lzFf7tzRgL0j4qXgYsYE=",
+      "dev": true,
+      "requires": {
+        "@cnakazawa/watch": "^1.0.3",
+        "anymatch": "^2.0.0",
+        "capture-exit": "^1.2.0",
+        "exec-sh": "^0.3.2",
+        "execa": "^1.0.0",
+        "fb-watchman": "^2.0.0",
+        "micromatch": "^3.1.4",
+        "minimist": "^1.1.1",
+        "walker": "~1.0.5"
+      }
     },
     "sass-loader": {
       "version": "7.1.0",
@@ -9143,6 +11297,12 @@
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
       "dev": true
     },
+    "shellwords": {
+      "version": "0.1.1",
+      "resolved": "http://registry.npm.taobao.org/shellwords/download/shellwords-0.1.1.tgz",
+      "integrity": "sha1-1rkYHBpI05cyTISHHvvPxz/AZUs=",
+      "dev": true
+    },
     "signal-exit": {
       "version": "3.0.2",
       "resolved": "http://registry.npm.taobao.org/signal-exit/download/signal-exit-3.0.2.tgz",
@@ -9174,6 +11334,12 @@
           "dev": true
         }
       }
+    },
+    "sisteransi": {
+      "version": "1.0.0",
+      "resolved": "http://registry.npm.taobao.org/sisteransi/download/sisteransi-1.0.0.tgz",
+      "integrity": "sha1-d9liL/kJCA8cGeX0od8MGwonuIw=",
+      "dev": true
     },
     "slash": {
       "version": "2.0.0",
@@ -9526,6 +11692,23 @@
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
+    "sshpk": {
+      "version": "1.16.1",
+      "resolved": "http://registry.npm.taobao.org/sshpk/download/sshpk-1.16.1.tgz",
+      "integrity": "sha1-+2YcC+8ps520B2nuOfpwCT1vaHc=",
+      "dev": true,
+      "requires": {
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
+        "tweetnacl": "~0.14.0"
+      }
+    },
     "ssri": {
       "version": "6.0.1",
       "resolved": "http://registry.npm.taobao.org/ssri/download/ssri-6.0.1.tgz",
@@ -9534,6 +11717,12 @@
       "requires": {
         "figgy-pudding": "^3.5.1"
       }
+    },
+    "stack-utils": {
+      "version": "1.0.2",
+      "resolved": "http://registry.npm.taobao.org/stack-utils/download/stack-utils-1.0.2.tgz",
+      "integrity": "sha1-M+ujiXeIVYvr/C2wWdwVjsNs67g=",
+      "dev": true
     },
     "staged-git-files": {
       "version": "1.1.2",
@@ -9572,6 +11761,12 @@
       "version": "1.4.0",
       "resolved": "http://registry.npm.taobao.org/statuses/download/statuses-1.4.0.tgz",
       "integrity": "sha1-u3PURtonlhBu/MG2AaJT1sRr0Ic=",
+      "dev": true
+    },
+    "stealthy-require": {
+      "version": "1.1.1",
+      "resolved": "http://registry.npm.taobao.org/stealthy-require/download/stealthy-require-1.1.1.tgz",
+      "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
       "dev": true
     },
     "stream-browserify": {
@@ -9619,6 +11814,16 @@
       "integrity": "sha1-2sMECGkMIfPDYwo/86BYd73L1zY=",
       "dev": true
     },
+    "string-length": {
+      "version": "2.0.0",
+      "resolved": "http://registry.npm.taobao.org/string-length/download/string-length-2.0.0.tgz",
+      "integrity": "sha1-1A27aGo6zpYMHP/KVivyxF+DY+0=",
+      "dev": true,
+      "requires": {
+        "astral-regex": "^1.0.0",
+        "strip-ansi": "^4.0.0"
+      }
+    },
     "string-width": {
       "version": "2.1.1",
       "resolved": "http://registry.npm.taobao.org/string-width/download/string-width-2.1.1.tgz",
@@ -9627,6 +11832,17 @@
       "requires": {
         "is-fullwidth-code-point": "^2.0.0",
         "strip-ansi": "^4.0.0"
+      }
+    },
+    "string.prototype.trim": {
+      "version": "1.1.2",
+      "resolved": "http://registry.npm.taobao.org/string.prototype.trim/download/string.prototype.trim-1.1.2.tgz",
+      "integrity": "sha1-0E3iyJ4Tf019IG8Ia17S+ua+jOo=",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.5.0",
+        "function-bind": "^1.0.2"
       }
     },
     "string_decoder": {
@@ -9770,6 +11986,12 @@
       "integrity": "sha1-wiaIrtTqs83C3+rLtWFmBWCgCAQ=",
       "dev": true
     },
+    "symbol-tree": {
+      "version": "3.2.2",
+      "resolved": "http://registry.npm.taobao.org/symbol-tree/download/symbol-tree-3.2.2.tgz",
+      "integrity": "sha1-rifbOPZgp64uHDt9G8KQgZuFGeY=",
+      "dev": true
+    },
     "synchronous-promise": {
       "version": "2.0.6",
       "resolved": "http://registry.npm.taobao.org/synchronous-promise/download/synchronous-promise-2.0.6.tgz",
@@ -9888,6 +12110,73 @@
         }
       }
     },
+    "test-exclude": {
+      "version": "5.1.0",
+      "resolved": "http://registry.npm.taobao.org/test-exclude/download/test-exclude-5.1.0.tgz",
+      "integrity": "sha1-a6ayUXnS04ckgkZhMjtz4DwMHeE=",
+      "dev": true,
+      "requires": {
+        "arrify": "^1.0.1",
+        "minimatch": "^3.0.4",
+        "read-pkg-up": "^4.0.0",
+        "require-main-filename": "^1.0.1"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "3.0.0",
+          "resolved": "http://registry.npm.taobao.org/find-up/download/find-up-3.0.0.tgz",
+          "integrity": "sha1-SRafHXmTQwZG2mHsxa41XCHJe3M=",
+          "dev": true,
+          "requires": {
+            "locate-path": "^3.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "3.0.0",
+          "resolved": "http://registry.npm.taobao.org/locate-path/download/locate-path-3.0.0.tgz",
+          "integrity": "sha1-2+w7OrdZdYBxtY/ln8QYca8hQA4=",
+          "dev": true,
+          "requires": {
+            "p-locate": "^3.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.2.0",
+          "resolved": "http://registry.npm.taobao.org/p-limit/download/p-limit-2.2.0.tgz",
+          "integrity": "sha1-QXyZQeYCepq8ulCS3SkE4lW1+8I=",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "3.0.0",
+          "resolved": "http://registry.npm.taobao.org/p-locate/download/p-locate-3.0.0.tgz",
+          "integrity": "sha1-Mi1poFwCZLJZl9n0DNiokasAZKQ=",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.0.0"
+          }
+        },
+        "p-try": {
+          "version": "2.0.0",
+          "resolved": "http://registry.npm.taobao.org/p-try/download/p-try-2.0.0.tgz",
+          "integrity": "sha1-hQgLuHxkaI+keZb+j3376CEXYLE=",
+          "dev": true
+        },
+        "read-pkg-up": {
+          "version": "4.0.0",
+          "resolved": "http://registry.npm.taobao.org/read-pkg-up/download/read-pkg-up-4.0.0.tgz",
+          "integrity": "sha1-GyIcYIi6d5lgHICPkRYcZuWPiXg=",
+          "dev": true,
+          "requires": {
+            "find-up": "^3.0.0",
+            "read-pkg": "^3.0.0"
+          }
+        }
+      }
+    },
     "text-extensions": {
       "version": "1.9.0",
       "resolved": "http://registry.npm.taobao.org/text-extensions/download/text-extensions-1.9.0.tgz",
@@ -9898,6 +12187,12 @@
       "version": "0.2.0",
       "resolved": "http://registry.npm.taobao.org/text-table/download/text-table-0.2.0.tgz",
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+      "dev": true
+    },
+    "throat": {
+      "version": "4.1.0",
+      "resolved": "http://registry.npm.taobao.org/throat/download/throat-4.1.0.tgz",
+      "integrity": "sha1-iQN8vJLFarGJJua6TLsgDhVnKmo=",
       "dev": true
     },
     "through": {
@@ -9939,6 +12234,12 @@
       "requires": {
         "os-tmpdir": "~1.0.2"
       }
+    },
+    "tmpl": {
+      "version": "1.0.4",
+      "resolved": "http://registry.npm.taobao.org/tmpl/download/tmpl-1.0.4.tgz",
+      "integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE=",
+      "dev": true
     },
     "to-arraybuffer": {
       "version": "1.0.1",
@@ -10000,6 +12301,25 @@
       "integrity": "sha1-LmhELZ9k7HILjMieZEOsbKqVACk=",
       "dev": true
     },
+    "tough-cookie": {
+      "version": "2.5.0",
+      "resolved": "http://registry.npm.taobao.org/tough-cookie/download/tough-cookie-2.5.0.tgz",
+      "integrity": "sha1-zZ+yoKodWhK0c72fuW+j3P9lreI=",
+      "dev": true,
+      "requires": {
+        "psl": "^1.1.28",
+        "punycode": "^2.1.1"
+      }
+    },
+    "tr46": {
+      "version": "1.0.1",
+      "resolved": "http://registry.npm.taobao.org/tr46/download/tr46-1.0.1.tgz",
+      "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
+      "dev": true,
+      "requires": {
+        "punycode": "^2.1.0"
+      }
+    },
     "trim": {
       "version": "0.0.1",
       "resolved": "http://registry.npm.taobao.org/trim/download/trim-0.0.1.tgz",
@@ -10046,6 +12366,21 @@
       "version": "0.0.0",
       "resolved": "http://registry.npm.taobao.org/tty-browserify/download/tty-browserify-0.0.0.tgz",
       "integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY=",
+      "dev": true
+    },
+    "tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "http://registry.npm.taobao.org/tunnel-agent/download/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "http://registry.npm.taobao.org/tweetnacl/download/tweetnacl-0.14.5.tgz",
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
       "dev": true
     },
     "type-check": {
@@ -10457,6 +12792,17 @@
       "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
       "dev": true
     },
+    "verror": {
+      "version": "1.10.0",
+      "resolved": "http://registry.npm.taobao.org/verror/download/verror-1.10.0.tgz",
+      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "^1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "^1.2.0"
+      }
+    },
     "vfile": {
       "version": "2.3.0",
       "resolved": "http://registry.npm.taobao.org/vfile/download/vfile-2.3.0.tgz",
@@ -10493,6 +12839,24 @@
         "indexof": "0.0.1"
       }
     },
+    "w3c-hr-time": {
+      "version": "1.0.1",
+      "resolved": "http://registry.npm.taobao.org/w3c-hr-time/download/w3c-hr-time-1.0.1.tgz",
+      "integrity": "sha1-gqwr/2PZUOqeMYmlimViX+3xkEU=",
+      "dev": true,
+      "requires": {
+        "browser-process-hrtime": "^0.1.2"
+      }
+    },
+    "walker": {
+      "version": "1.0.7",
+      "resolved": "http://registry.npm.taobao.org/walker/download/walker-1.0.7.tgz",
+      "integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
+      "dev": true,
+      "requires": {
+        "makeerror": "1.0.x"
+      }
+    },
     "warning": {
       "version": "4.0.2",
       "resolved": "http://registry.npm.taobao.org/warning/download/warning-4.0.2.tgz",
@@ -10521,6 +12885,12 @@
       "requires": {
         "minimalistic-assert": "^1.0.0"
       }
+    },
+    "webidl-conversions": {
+      "version": "4.0.2",
+      "resolved": "http://registry.npm.taobao.org/webidl-conversions/download/webidl-conversions-4.0.2.tgz",
+      "integrity": "sha1-qFWYCx8LazWbodXZ+zmulB+qY60=",
+      "dev": true
     },
     "webpack": {
       "version": "4.26.0",
@@ -10811,6 +13181,43 @@
       "integrity": "sha1-XS/yKXcAPsaHpLhwc9+7rBRszyk=",
       "dev": true
     },
+    "whatwg-encoding": {
+      "version": "1.0.5",
+      "resolved": "http://registry.npm.taobao.org/whatwg-encoding/download/whatwg-encoding-1.0.5.tgz",
+      "integrity": "sha1-WrrPd3wyFmpR0IXWtPPn0nET3bA=",
+      "dev": true,
+      "requires": {
+        "iconv-lite": "0.4.24"
+      },
+      "dependencies": {
+        "iconv-lite": {
+          "version": "0.4.24",
+          "resolved": "http://registry.npm.taobao.org/iconv-lite/download/iconv-lite-0.4.24.tgz",
+          "integrity": "sha1-ICK0sl+93CHS9SSXSkdKr+czkIs=",
+          "dev": true,
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3"
+          }
+        }
+      }
+    },
+    "whatwg-mimetype": {
+      "version": "2.3.0",
+      "resolved": "http://registry.npm.taobao.org/whatwg-mimetype/download/whatwg-mimetype-2.3.0.tgz",
+      "integrity": "sha1-PUseAxLSB5h5+Cav8Y2+7KWWD78=",
+      "dev": true
+    },
+    "whatwg-url": {
+      "version": "6.5.0",
+      "resolved": "http://registry.npm.taobao.org/whatwg-url/download/whatwg-url-6.5.0.tgz",
+      "integrity": "sha1-8t8Cv/F2/WUHDfdK1cy7WhmZZag=",
+      "dev": true,
+      "requires": {
+        "lodash.sortby": "^4.7.0",
+        "tr46": "^1.0.1",
+        "webidl-conversions": "^4.0.2"
+      }
+    },
     "when": {
       "version": "3.6.4",
       "resolved": "http://registry.npm.taobao.org/when/download/when-3.6.4.tgz",
@@ -10909,10 +13316,36 @@
         "mkdirp": "^0.5.1"
       }
     },
+    "write-file-atomic": {
+      "version": "2.4.1",
+      "resolved": "http://registry.npm.taobao.org/write-file-atomic/download/write-file-atomic-2.4.1.tgz",
+      "integrity": "sha1-0LBUY8GIroBDlv1asqNwBir4dSk=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.11",
+        "imurmurhash": "^0.1.4",
+        "signal-exit": "^3.0.2"
+      }
+    },
+    "ws": {
+      "version": "5.2.2",
+      "resolved": "http://registry.npm.taobao.org/ws/download/ws-5.2.2.tgz",
+      "integrity": "sha1-3/7xSGa46NyRM1glFNG++vlumA8=",
+      "dev": true,
+      "requires": {
+        "async-limiter": "~1.0.0"
+      }
+    },
     "x-is-string": {
       "version": "0.1.0",
       "resolved": "http://registry.npm.taobao.org/x-is-string/download/x-is-string-0.1.0.tgz",
       "integrity": "sha1-R0tQhlrzpJqcRlfwWs0UVFj3fYI=",
+      "dev": true
+    },
+    "xml-name-validator": {
+      "version": "3.0.0",
+      "resolved": "http://registry.npm.taobao.org/xml-name-validator/download/xml-name-validator-3.0.0.tgz",
+      "integrity": "sha1-auc+Bt5NjG5H+fsYH3jWSK1FfGo=",
       "dev": true
     },
     "xregexp": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "doc:dev": "webpack-dev-server --config scripts/webpack.doc.js",
     "example": "webpack-dev-server --config scripts/webpack.example.js",
     "lint": "tslint -c tslint.json -t codeFrame 'src/**/*.tsx' 'src/**/*.ts' 'site/**/*.ts' 'site/**/*.tsx' 'example/**/*.tsx', 'example/**/*.ts'",
-    "type-check": "tsc"
+    "type-check": "tsc",
+    "test": "jest"
   },
   "repository": {
     "type": "git",
@@ -41,11 +42,15 @@
     "@typescript-eslint/eslint-plugin": "^1.4.2",
     "@typescript-eslint/parser": "^1.4.2",
     "awesome-typescript-loader": "^5.2.1",
+    "babel-jest": "^24.5.0",
     "babel-loader": "^8.0.4",
     "babel-plugin-no-debugging": "^1.3.1",
     "commitlint": "^7.2.1",
     "cross-env": "^5.2.0",
     "css-loader": "^1.0.1",
+    "enzyme": "^3.9.0",
+    "enzyme-adapter-react-16": "^1.11.0",
+    "enzyme-to-json": "^3.3.5",
     "eslint": "^5.15.1",
     "eslint-config-airbnb-typescript": "^1.1.0",
     "eslint-config-prettier": "^4.1.0",
@@ -60,6 +65,7 @@
     "html-loader": "^0.5.5",
     "html-webpack-plugin": "^3.2.0",
     "husky": "^1.2.0",
+    "jest": "^24.5.0",
     "json-loader": "^0.5.7",
     "lint-staged": "^8.1.5",
     "loader-utils": "^1.1.0",

--- a/scripts/jest/__mocks__/fileMock.js
+++ b/scripts/jest/__mocks__/fileMock.js
@@ -1,0 +1,1 @@
+module.exports = 'test-file-stub';

--- a/scripts/jest/__mocks__/styleMock.js
+++ b/scripts/jest/__mocks__/styleMock.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/scripts/jest/setupTests.js
+++ b/scripts/jest/setupTests.js
@@ -1,0 +1,4 @@
+import { configure } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+
+configure({ adapter: new Adapter() });

--- a/src/components/button/__test__/__snapshots__/index.test.jsx.snap
+++ b/src/components/button/__test__/__snapshots__/index.test.jsx.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`MyComponent should render correctly in "debug" mode 1`] = `
+<button
+  className=" cube-btn"
+  onClick={[Function]}
+  type="button"
+/>
+`;

--- a/src/components/button/__test__/index.test.jsx
+++ b/src/components/button/__test__/index.test.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import Button from '../index.tsx';
+
+describe('MyComponent', () => {
+  it('should render correctly in "debug" mode', () => {
+    const component = shallow(<Button />);
+    expect(component).toMatchSnapshot();
+  });
+});

--- a/src/components/button/index.tsx
+++ b/src/components/button/index.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import classnames from 'classnames';
 import './index.styl';
 
@@ -10,14 +10,14 @@ export interface BasicProps {
 	primary?: boolean;
 	outline?: boolean;
 	light?: boolean;
-	type?: string;
+	type?: 'button' | 'submit' | 'reset';
 	onClick?: (e?: MouseEvent) => void;
 }
 
 type ButtonProps = React.ButtonHTMLAttributes<{}> & BasicProps;
 
-export default class Button extends React.Component<ButtonProps, any> {
-	static defaultProps = {
+export default class Button extends React.Component<ButtonProps> {
+	private static defaultProps: BasicProps = {
 		icon: '',
 		active: false,
 		disabled: false,
@@ -29,9 +29,9 @@ export default class Button extends React.Component<ButtonProps, any> {
 		onClick: () => {}
 	};
 
-	render() {
+	public render(): React.ReactNode {
 		const { props } = this;
-		const { icon, active, disabled, inline, primary, outline, light, type, onClick } = props;
+		const { icon, active, disabled, inline, primary, outline, light, type, onClick, children } = props;
 		const classes = classnames({
 			'cube-btn_active': active,
 			'cube-btn_disabled': disabled,
@@ -44,7 +44,7 @@ export default class Button extends React.Component<ButtonProps, any> {
 		return (
 			<button className={`${classes} cube-btn`} type={type} onClick={(e) => !disabled && onClick(e)}>
 				{icon && <i className={icon} />}
-				{this.props.children}
+				{children}
 			</button>
 		);
 	}


### PR DESCRIPTION
What should be noticed:
* Jest is running in node environment, But our source code is written in es6+ with import/export API, So we should let jest  knows to use babel to transpile source code, babel-jest do the job.
* Current .babelrc uses @babel/preset-env with option `modules: false`, this let webpack to do the bundle work. But in jest world, no webpack used, So Babel should do the bundle job. So in test enviroment, we should set `modules: commonjs`, that's why move .babelrc to babel.config.js
* Refer to [Handling Static Assets](https://jestjs.io/docs/en/webpack.html#handling-static-assets), stylesheet and image files aren't particularly useful in tests so we can safely mock them out, So some mock file should be added